### PR TITLE
Add test data from github; rename json response to getJSONStringAssig… …nment (FF-890, FF-900)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,16 @@ test:
 	swift test
 
 ## test-data
-testDataDir := Tests/eppo/Resources/test-data
+testDataDir := Tests/eppo/Resources/test-data/
+tempDir := ${testDataDir}temp/
+gitDataDir := ${tempDir}sdk-test-data/
+branchName := main
+githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 .PHONY: test-data
-test-data: 
+test-data:
 	rm -rf $(testDataDir)
-	mkdir -p $(testDataDir)
-	gsutil cp gs://sdk-test-data/rac-experiments-v*.json $(testDataDir)
-	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
+	mkdir -p $(tempDir)
+	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
+	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	rm -rf ${tempDir}

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -135,6 +135,7 @@ public class EppoClient {
             return nil;
         }
 
+        // Access the stringified JSON from `value` field until support for native JSON is available.
         if (isJson) {
             return EppoValue(value: assignedVariation.value, type: EppoValueType.String);
         }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -50,7 +50,7 @@ public class EppoClient {
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes) throws -> String?
     {
-        return try getStringAssignment(subjectKey, flagKey, subjectAttributes)
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, false)?.stringValue()
     }
 
     public func getBoolAssignment(
@@ -58,7 +58,7 @@ public class EppoClient {
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> Bool?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes)?.boolValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.boolValue()
     }
     
     public func getJSONStringAssignment(
@@ -66,7 +66,7 @@ public class EppoClient {
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> String?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.stringValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, false)?.stringValue()
     }
     
     public func getNumericAssignment(
@@ -74,7 +74,7 @@ public class EppoClient {
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> Double?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes)?.doubleValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.doubleValue()
     }
     
     public func getStringAssignment(
@@ -82,14 +82,14 @@ public class EppoClient {
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> String?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes)?.stringValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.stringValue()
     }
     
     private func getInternalAssignment(
         _ subjectKey: String,
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes,
-        _ isJson: Bool = false) throws -> EppoValue?
+        _ useTypedVariationValue: Bool) throws -> EppoValue?
     {
         try self.validate();
 
@@ -135,11 +135,13 @@ public class EppoClient {
             return nil;
         }
 
-        // Access the stringified JSON from `value` field until support for native JSON is available.
-        if (isJson) {
+        if (useTypedVariationValue) {
+            return assignedVariation.typedValue;
+        } else {
+            // Access the stringified JSON from `value` field until support for native JSON is available.
+            // The legacy getAssignment method accesses the existing field to consistency return a stringified value.
             return EppoValue(value: assignedVariation.value, type: EppoValueType.String);
         }
-        return assignedVariation.typedValue;
     }
 
     public func validate() throws {

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -45,21 +45,36 @@ public class EppoClient {
         self.flagConfigs = try JSONDecoder().decode(FlagConfigJSON.self, from: urlData);
     }
     
+    public func getAssignment(
+        _ subjectKey: String,
+        _ flagKey: String,
+        _ subjectAttributes: SubjectAttributes) throws -> String?
+    {
+        return try getStringAssignment(subjectKey, flagKey, subjectAttributes)
+    }
+
     public func getBoolAssignment(
         _ subjectKey: String,
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> Bool?
     {
-        return try getAssignment(subjectKey, flagKey, subjectAttributes)?.boolValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes)?.boolValue()
     }
     
+    public func getJSONStringAssignment(
+        _ subjectKey: String,
+        _ flagKey: String,
+        _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> String?
+    {
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.stringValue()
+    }
     
     public func getNumericAssignment(
         _ subjectKey: String,
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> Double?
     {
-        return try getAssignment(subjectKey, flagKey, subjectAttributes)?.doubleValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes)?.doubleValue()
     }
     
     public func getStringAssignment(
@@ -67,17 +82,14 @@ public class EppoClient {
         _ flagKey: String,
         _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> String?
     {
-        return try getAssignment(subjectKey, flagKey, subjectAttributes)?.stringValue()
+        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes)?.stringValue()
     }
     
-    private func getAssignment(_ subjectKey: String, _ flagKey: String) throws -> EppoValue? {
-        return try getAssignment(subjectKey, flagKey, [:]);
-    }
-
-    private func getAssignment(
+    private func getInternalAssignment(
         _ subjectKey: String,
         _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes) throws -> EppoValue?
+        _ subjectAttributes: SubjectAttributes,
+        _ isJson: Bool = false) throws -> EppoValue?
     {
         try self.validate();
 
@@ -123,6 +135,9 @@ public class EppoClient {
             return nil;
         }
 
+        if (isJson) {
+            return EppoValue(value: assignedVariation.value, type: EppoValueType.String);
+        }
         return assignedVariation.typedValue;
     }
 

--- a/Sources/eppo/dto/EppoValue.swift
+++ b/Sources/eppo/dto/EppoValue.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum EppoValueType {
     case Number
     case String
@@ -134,7 +132,6 @@ public class EppoValue : Decodable, Equatable {
     }
 
     public func stringValue() throws -> String {
-        //print("string")
         if self.value == nil {
             throw Errors.valueNotSet;
         }

--- a/Sources/eppo/dto/EppoValue.swift
+++ b/Sources/eppo/dto/EppoValue.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public enum EppoValueType {
     case Number
     case String
@@ -51,7 +53,7 @@ public class EppoValue : Decodable, Equatable {
 
     required public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer();
-
+        
         try? self.array = container.decode([String].self);
         if self.array != nil {
             self.type = EppoValueType.ArrayOfStrings;
@@ -132,6 +134,7 @@ public class EppoValue : Decodable, Equatable {
     }
 
     public func stringValue() throws -> String {
+        //print("string")
         if self.value == nil {
             throw Errors.valueNotSet;
         }

--- a/Sources/eppo/dto/Variation.swift
+++ b/Sources/eppo/dto/Variation.swift
@@ -1,4 +1,5 @@
 struct Variation: Decodable {
+    var value: String;
     var typedValue: EppoValue;
     var shardRange: ShardRange;
 }


### PR DESCRIPTION
**api changes**

* Add back `getAssignment` for backwards compatibility
* Add `getJSONStringAssignment` that returns a `String`

**implementation details**

We are returning stringified JSON - in order to simplify the implementation we do not need to parse the string into swift json and back to a string. Instead we are supporting both `value` and `typedValue` fields in `Variation` - in the case of requesting a JSON response we read and pass-through the stringified JSON.

https://www.loom.com/share/6f2dc59f9192487486da11129f97f461

**house-keeping**

* add test data files from github to be able to share across SDK repos

**testing**

all unit tests pass