### PR TITLE
Make Assignment attributes public.

### DIFF
--- a/Sources/eppo/Assignment.swift
+++ b/Sources/eppo/Assignment.swift
@@ -1,11 +1,11 @@
 public class Assignment : CustomStringConvertible {
-    var allocation: String = "";
-    var experiment: String = "";
-    var featureFlag: String = "";
-    var variation: String = "";
-    var subject: String = "";
-    var timestamp: String = "";
-    var subjectAttributes: SubjectAttributes;
+    public var allocation: String = "";
+    public var experiment: String = "";
+    public var featureFlag: String = "";
+    public var variation: String = "";
+    public var subject: String = "";
+    public var timestamp: String = "";
+    public var subjectAttributes: SubjectAttributes;
     
     public var description: String {
         return "Subject " + subject + " assigned to variation " + variation + " in experiment " + experiment;


### PR DESCRIPTION
## problem

Attributes are not accessible for the purposes of logging.

## description

Make attributes public.