### PR TITLE
correction for allocation key logging (FF-1755)

### DIFF
--- a/Sources/eppo/Assignment.swift
+++ b/Sources/eppo/Assignment.swift
@@ -12,12 +12,12 @@ public class Assignment : CustomStringConvertible {
     }
 
     public init(
-        _ flagKey: String,
-        _ allocationKey: String,
-        _ variation: String,
-        _ subject: String,
-        _ timestamp: String,
-        _ subjectAttributes: SubjectAttributes
+        flagKey: String,
+        allocationKey: String,
+        variation: String,
+        subject: String,
+        timestamp: String,
+        subjectAttributes: SubjectAttributes
     )
     {
         self.allocation = allocationKey;

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -144,12 +144,12 @@ public class EppoClient {
         
         // optionally log assignment
         let assignment = Assignment(
-            flagKey,
-            flagKey + "-" + rule.allocationKey,
-            assignedVariation.value,
-            subjectKey,
-            ISO8601DateFormatter().string(from: Date()),
-            subjectAttributes
+            flagKey: flagKey,
+            allocationKey: rule.allocationKey,
+            variation: assignedVariation.value,
+            subject: subjectKey,
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            subjectAttributes: subjectAttributes
         )
         self.assignmentLogger?(assignment);
         

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -151,7 +151,6 @@ public class EppoClient {
             timestamp: ISO8601DateFormatter().string(from: Date()),
             subjectAttributes: subjectAttributes
         )
-        //print("ASSIGNMENT", assignment)
         self.assignmentLogger?(assignment);
         
         if (useTypedVariationValue) {

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -151,6 +151,7 @@ public class EppoClient {
             timestamp: ISO8601DateFormatter().string(from: Date()),
             subjectAttributes: subjectAttributes
         )
+        //print("ASSIGNMENT", assignment)
         self.assignmentLogger?(assignment);
         
         if (useTypedVariationValue) {

--- a/Tests/eppo/AssignmentTests.swift
+++ b/Tests/eppo/AssignmentTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import eppo_flagging
+
+final class AssignmentTests: XCTestCase {
+    func testAssignmentInitialization() {
+        let subjectAttributes = SubjectAttributes()
+        let assignment = Assignment(
+            flagKey: "featureA",
+            allocationKey: "allocation1",
+            variation: "variationB",
+            subject: "user123",
+            timestamp: "2024-03-19T12:34:56Z",
+            subjectAttributes: subjectAttributes
+        )
+        
+        XCTAssertEqual(assignment.allocation, "allocation1")
+        XCTAssertEqual(assignment.experiment, "featureA-allocation1")
+        XCTAssertEqual(assignment.featureFlag, "featureA")
+        XCTAssertEqual(assignment.variation, "variationB")
+        XCTAssertEqual(assignment.subject, "user123")
+        XCTAssertEqual(assignment.timestamp, "2024-03-19T12:34:56Z")
+        XCTAssertEqual(assignment.subjectAttributes, subjectAttributes)
+    }
+    
+    func testAssignmentDescription() {
+        let subjectAttributes = SubjectAttributes()
+        let assignment = Assignment(
+            flagKey: "featureB",
+            allocationKey: "allocation2",
+            variation: "variationA",
+            subject: "user456",
+            timestamp: "2024-03-20T12:34:56Z",
+            subjectAttributes: subjectAttributes
+        )
+        
+        let expectedDescription = "Subject user456 assigned to variation variationA in experiment featureB-allocation2"
+        XCTAssertEqual(assignment.description, expectedDescription)
+    }
+}

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -176,7 +176,10 @@ final class eppoClientTests: XCTestCase {
             XCTAssertTrue(loggerSpy.wasCalled, "Assignment logger was not called.")
             if let lastAssignment = loggerSpy.lastAssignment {
                 XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.allocation))
-                XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.experiment))
+                XCTAssertTrue(lastAssignment.experiment.count > lastAssignment.allocation.count)
+
+                XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.featureFlag))
+                XCTAssertTrue(lastAssignment.experiment.count > lastAssignment.featureFlag.count)
             } else {
                 XCTFail("No last assignment was logged.")
             }

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -108,39 +108,52 @@ struct AssignmentTestCase : Decodable {
     }
 }
 
-final class eppoClientTests: XCTestCase {
-    var loggerSpy: AssignmentLoggerSpy!
-    var eppoClient: EppoClient!
-    
-    override func setUp() {
-        super.setUp()
-        // Initialize loggerSpy here
-        loggerSpy = AssignmentLoggerSpy()
-        // Now that loggerSpy is initialized, we can use it to initialize eppoClient
-        eppoClient = EppoClient("mock-api-key",
+final class eppoClientTests: XCTestCase {    
+    func testUnloadedClient() async throws {
+        let loggerSpy = AssignmentLoggerSpy()
+        let eppoClient = EppoClient("mock-api-key",
                                 host: "http://localhost:4001",
                                 assignmentLogger: loggerSpy.logger)
-    }
-    
-    func testUnloadedClient() async throws {
-        XCTAssertThrowsError(try self.eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
+        XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
         {
             error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.configurationNotLoaded)
         };
     }
 
     func testBadFlagKey() async throws {
-        try await self.eppoClient.load(httpClient: EppoMockHttpClient());
+        let loggerSpy = AssignmentLoggerSpy()
+        let eppoClient = EppoClient("mock-api-key",
+                                host: "http://localhost:4001",
+                                assignmentLogger: loggerSpy.logger)
 
-        XCTAssertThrowsError(try self.eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
+        try await eppoClient.load(httpClient: EppoMockHttpClient());
+
+        XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
         {
             error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.flagConfigNotFound)
         };
     }
 
-    func testAssignments() async throws {
-        try await self.eppoClient.load(httpClient: EppoMockHttpClient());
+    func testLogger() async throws {
+        let loggerSpy = AssignmentLoggerSpy()
+        let eppoClient = EppoClient("mock-api-key",
+                                    host: "http://localhost:4001",
+                                    assignmentLogger: loggerSpy.logger)
+        try await eppoClient.load(httpClient: EppoMockHttpClient());
 
+        let assignment = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+        XCTAssertEqual(assignment, "red")
+        XCTAssertTrue(loggerSpy.wasCalled)
+        if let lastAssignment = loggerSpy.lastAssignment {
+            XCTAssertEqual(lastAssignment.allocation, "allocation-experiment-1")
+            XCTAssertEqual(lastAssignment.experiment, "randomization_algo-allocation-experiment-1")
+            XCTAssertEqual(lastAssignment.subject, "6255e1a72a84e984aed55668")
+        } else {
+            XCTFail("No last assignment was logged.")
+        }
+    }
+
+    func testAssignments() async throws {
         let testFiles = Bundle.module.paths(
             forResourcesOfType: ".json",
             inDirectory: "Resources/test-data/assignment-v2"
@@ -151,39 +164,33 @@ final class eppoClientTests: XCTestCase {
             let caseData = caseString.data(using: .utf8)!;
             let testCase = try JSONDecoder().decode(AssignmentTestCase.self, from: caseData);
 
+            let loggerSpy = AssignmentLoggerSpy()
+            let eppoClient = EppoClient("mock-api-key",
+                                    host: "http://localhost:4001",
+                                    assignmentLogger: loggerSpy.logger)
+
+            try await eppoClient.load(httpClient: EppoMockHttpClient());
+
             switch (testCase.valueType) {
                 case "boolean":
-                    let assignments = try testCase.boolAssignments(self.eppoClient);
+                    let assignments = try testCase.boolAssignments(eppoClient);
                     let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() }
                     XCTAssertEqual(assignments, expectedAssignments);
                 case "json":
-                    let assignments = try testCase.jsonAssignments(self.eppoClient);
+                    let assignments = try testCase.jsonAssignments(eppoClient);
                     let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
                     XCTAssertEqual(assignments, expectedAssignments);
                 case "numeric":
-                    let assignments = try testCase.numericAssignments(self.eppoClient);
+                    let assignments = try testCase.numericAssignments(eppoClient);
                     let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() }
                     XCTAssertEqual(assignments, expectedAssignments);
                 case "string":
-                    let assignments = try testCase.stringAssignments(self.eppoClient);
+                    let assignments = try testCase.stringAssignments(eppoClient);
                     let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
                     XCTAssertEqual(assignments, expectedAssignments);
                 default:
                     XCTFail("Unknown value type: \(testCase.valueType)");
             }
-            
-
-            XCTAssertTrue(loggerSpy.wasCalled, "Assignment logger was not called.")
-            if let lastAssignment = loggerSpy.lastAssignment {
-                XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.allocation))
-                XCTAssertTrue(lastAssignment.experiment.count > lastAssignment.allocation.count)
-
-                XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.featureFlag))
-                XCTAssertTrue(lastAssignment.experiment.count > lastAssignment.featureFlag.count)
-            } else {
-                XCTFail("No last assignment was logged.")
-            }
-
         }
 
         XCTAssertGreaterThan(testFiles.count, 0);

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -172,7 +172,14 @@ final class eppoClientTests: XCTestCase {
                     XCTFail("Unknown value type: \(testCase.valueType)");
             }
             
+
             XCTAssertTrue(loggerSpy.wasCalled, "Assignment logger was not called.")
+            if let lastAssignment = loggerSpy.lastAssignment {
+                XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.allocation))
+                XCTAssertTrue(lastAssignment.experiment.contains(lastAssignment.experiment))
+            } else {
+                XCTFail("No last assignment was logged.")
+            }
 
         }
 

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -108,12 +108,19 @@ struct AssignmentTestCase : Decodable {
     }
 }
 
-final class eppoClientTests: XCTestCase {    
-    func testUnloadedClient() async throws {
-        let loggerSpy = AssignmentLoggerSpy()
-        let eppoClient = EppoClient("mock-api-key",
+final class eppoClientTests: XCTestCase {   
+    var loggerSpy: AssignmentLoggerSpy!
+    var eppoClient: EppoClient!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        loggerSpy = AssignmentLoggerSpy()
+        eppoClient = EppoClient("mock-api-key",
                                 host: "http://localhost:4001",
                                 assignmentLogger: loggerSpy.logger)
+    }
+ 
+    func testUnloadedClient() async throws {
         XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
         {
             error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.configurationNotLoaded)
@@ -121,11 +128,6 @@ final class eppoClientTests: XCTestCase {
     }
 
     func testBadFlagKey() async throws {
-        let loggerSpy = AssignmentLoggerSpy()
-        let eppoClient = EppoClient("mock-api-key",
-                                host: "http://localhost:4001",
-                                assignmentLogger: loggerSpy.logger)
-
         try await eppoClient.load(httpClient: EppoMockHttpClient());
 
         XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
@@ -135,10 +137,6 @@ final class eppoClientTests: XCTestCase {
     }
 
     func testLogger() async throws {
-        let loggerSpy = AssignmentLoggerSpy()
-        let eppoClient = EppoClient("mock-api-key",
-                                    host: "http://localhost:4001",
-                                    assignmentLogger: loggerSpy.logger)
         try await eppoClient.load(httpClient: EppoMockHttpClient());
 
         let assignment = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
@@ -163,11 +161,6 @@ final class eppoClientTests: XCTestCase {
             let caseString = try String(contentsOfFile: testFile);
             let caseData = caseString.data(using: .utf8)!;
             let testCase = try JSONDecoder().decode(AssignmentTestCase.self, from: caseData);
-
-            let loggerSpy = AssignmentLoggerSpy()
-            let eppoClient = EppoClient("mock-api-key",
-                                    host: "http://localhost:4001",
-                                    assignmentLogger: loggerSpy.logger)
 
             try await eppoClient.load(httpClient: EppoMockHttpClient());
 


### PR DESCRIPTION
## undesired behavior

`allocation` logged with `flag` prefixed

## desired behavior

`allocation` is logged as received; `experiment` is concatenated between `flagKey` and `allocationKey`