### PR TITLE
Add assignment cache (FF-1821)

### DIFF
--- a/Sources/eppo/AssignmentCache.swift
+++ b/Sources/eppo/AssignmentCache.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public protocol AssignmentCache {
+    func hasLoggedAssignment(key: AssignmentCacheKey) -> Bool
+    func setLastLoggedAssignment(key: AssignmentCacheKey)
+}
+
+public struct AssignmentCacheKey {
+    var subjectKey: String
+    var flagKey: String
+    var allocationKey: String
+    var variationValue: EppoValue
+}
+
+public class InMemoryAssignmentCache: AssignmentCache {
+    private var cache: [String: String] = [:]
+
+    // This empty constructor is required to be able to instantiate the class
+    // within the constructor of EppoClient.
+    public init() {
+        // Initialization code here
+    }
+
+    public func hasLoggedAssignment(key: AssignmentCacheKey) -> Bool {
+        let cacheKey = getCacheKey(key: key)
+        if !has(key: cacheKey) {
+            return false
+        }
+
+        return get(key: cacheKey) == key.variationValue.toHashedString()
+    }
+
+    public func setLastLoggedAssignment(key: AssignmentCacheKey) {
+        let cacheKey = getCacheKey(key: key)
+        set(key: cacheKey, value: key.variationValue.toHashedString())
+    }
+
+    internal func get(key: String) -> String? {
+        return cache[key]
+    }
+
+    internal func set(key: String, value: String) {
+        cache[key] = value
+    }
+
+    internal func has(key: String) -> Bool {
+        return cache[key] != nil
+    }
+
+    private func getCacheKey(key: AssignmentCacheKey) -> String {
+        return ["subject:\(key.subjectKey)", "flag:\(key.flagKey)", "allocation:\(key.allocationKey)"].joined(separator: ";")
+    }
+}

--- a/Sources/eppo/dto/EppoValue.swift
+++ b/Sources/eppo/dto/EppoValue.swift
@@ -1,3 +1,6 @@
+import Foundation
+import CryptoKit
+
 public enum EppoValueType {
     case Number
     case String
@@ -137,5 +140,20 @@ public class EppoValue : Decodable, Equatable {
         }
 
         return self.value!;
+    }
+
+    public func toHashedString() -> String {
+        var str = ""
+        if let value = self.value {
+            str = value
+        } else if let array = self.array {
+            str = array.joined(separator: ",")
+        }
+
+        // generate a sha256 hash of the string. this is a 32-byte signature which 
+        // will likely save space when using json values but will almost certainly be
+        // longer than typical string variation values such as "control" or "variant".
+        let sha256Data = SHA256.hash(data: str.data(using: .utf8) ?? Data())
+        return sha256Data.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Tests/eppo/AssignmentCacheTests.swift
+++ b/Tests/eppo/AssignmentCacheTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+@testable import eppo_flagging
+
+final class AssignmentCacheTests: XCTestCase {
+    var cache: InMemoryAssignmentCache!
+    
+    override func setUp() {
+        super.setUp()
+        
+        cache = InMemoryAssignmentCache()
+    }
+    
+    override func tearDown() {
+        cache = nil
+        super.tearDown()
+    }
+    
+    func testSetAndGet() {
+        let key = "testKey"
+        let value = "testValue"
+        XCTAssertNil(cache.get(key: key), "Cache should return nil for a key that has not been set.")
+        cache.set(key: key, value: value)
+        XCTAssertEqual(cache.get(key: key), value, "Cache should return the value that was set for a key.")
+    }
+    
+    func testHas() {
+        let key = "testKey"
+        XCTAssertFalse(cache.has(key: key), "Cache should return false for a key that has not been set.")
+        cache.set(key: key, value: "testValue")
+        XCTAssertTrue(cache.has(key: key), "Cache should return true for a key that has been set.")
+    }
+    
+    func testHasLoggedAssignment() {
+        let assignmentKey = AssignmentCacheKey(
+            subjectKey: "Math", 
+            flagKey: "TestFlag",
+            allocationKey: "A1",
+            variationValue: EppoValue(value: "VariationA", type: EppoValueType.String)
+        )
+        
+        XCTAssertFalse(cache.hasLoggedAssignment(key: assignmentKey), "Cache should return false for an assignment that has not been logged.")
+        
+        cache.setLastLoggedAssignment(key: assignmentKey)
+        XCTAssertTrue(cache.hasLoggedAssignment(key: assignmentKey), "Cache should return true for an assignment that has been logged.")
+    }
+}

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -20,13 +20,30 @@ class EppoMockHttpClient: EppoHttpClient {
     public func post() throws {}
 }
 
-class AssignmentLoggerSpy {
+class EppoJSONAcceptorClient: EppoHttpClient {
+    var jsonResponse: Data?
+    
+    init(jsonResponse: String) {
+        self.jsonResponse = jsonResponse.data(using: .utf8)
+    }
+    
+    func get(_ url: URL) async throws -> (Data, URLResponse) {
+        guard let jsonData = jsonResponse else {
+            throw URLError(.badServerResponse)
+        }
+        return (jsonData, URLResponse(url: url, mimeType: "application/json", expectedContentLength: jsonData.count, textEncodingName: nil))
+    }
+}
+
+public class AssignmentLoggerSpy {
     var wasCalled = false
     var lastAssignment: Assignment?
+    var logCount = 0
 
     func logger(assignment: Assignment) {
         wasCalled = true
         lastAssignment = assignment
+        logCount += 1
     }
 }
 
@@ -108,84 +125,293 @@ struct AssignmentTestCase : Decodable {
     }
 }
 
-final class eppoClientTests: XCTestCase {   
+final class eppoClientTests: XCTestCase {
+   var loggerSpy: AssignmentLoggerSpy!
+   var eppoClient: EppoClient!
+   
+   override func setUpWithError() throws {
+       try super.setUpWithError()
+       loggerSpy = AssignmentLoggerSpy()
+       eppoClient = EppoClient("mock-api-key",
+                               host: "http://localhost:4001",
+                               assignmentLogger: loggerSpy.logger)
+   }
+   
+   func testUnloadedClient() async throws {
+       XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
+       {
+           error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.configurationNotLoaded)
+       };
+   }
+   
+   func testBadFlagKey() async throws {
+       try await eppoClient.load(httpClient: EppoMockHttpClient());
+       
+       XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
+       {
+           error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.flagConfigNotFound)
+       };
+   }
+   
+   func testLogger() async throws {
+       try await eppoClient.load(httpClient: EppoMockHttpClient());
+       
+       let assignment = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+       XCTAssertEqual(assignment, "red")
+       XCTAssertTrue(loggerSpy.wasCalled)
+       if let lastAssignment = loggerSpy.lastAssignment {
+           XCTAssertEqual(lastAssignment.allocation, "allocation-experiment-1")
+           XCTAssertEqual(lastAssignment.experiment, "randomization_algo-allocation-experiment-1")
+           XCTAssertEqual(lastAssignment.subject, "6255e1a72a84e984aed55668")
+       } else {
+           XCTFail("No last assignment was logged.")
+       }
+   }
+   
+   func testAssignments() async throws {
+       let testFiles = Bundle.module.paths(
+           forResourcesOfType: ".json",
+           inDirectory: "Resources/test-data/assignment-v2"
+       );
+       
+       for testFile in testFiles {
+           let caseString = try String(contentsOfFile: testFile);
+           let caseData = caseString.data(using: .utf8)!;
+           let testCase = try JSONDecoder().decode(AssignmentTestCase.self, from: caseData);
+           
+           try await eppoClient.load(httpClient: EppoMockHttpClient());
+           
+           switch (testCase.valueType) {
+           case "boolean":
+               let assignments = try testCase.boolAssignments(eppoClient);
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() }
+               XCTAssertEqual(assignments, expectedAssignments);
+           case "json":
+               let assignments = try testCase.jsonAssignments(eppoClient);
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
+               XCTAssertEqual(assignments, expectedAssignments);
+           case "numeric":
+               let assignments = try testCase.numericAssignments(eppoClient);
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() }
+               XCTAssertEqual(assignments, expectedAssignments);
+           case "string":
+               let assignments = try testCase.stringAssignments(eppoClient);
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
+               XCTAssertEqual(assignments, expectedAssignments);
+           default:
+               XCTFail("Unknown value type: \(testCase.valueType)");
+           }
+       }
+       
+       XCTAssertGreaterThan(testFiles.count, 0);
+   }
+}
+
+final class EppoClientAssignmentCachingTests: XCTestCase {
     var loggerSpy: AssignmentLoggerSpy!
     var eppoClient: EppoClient!
-
+    
     override func setUpWithError() throws {
         try super.setUpWithError()
         loggerSpy = AssignmentLoggerSpy()
         eppoClient = EppoClient("mock-api-key",
-                                host: "http://localhost:4001",
-                                assignmentLogger: loggerSpy.logger)
+                    host: "http://localhost:4001",
+                    assignmentLogger: loggerSpy.logger
+                    // InMemoryAssignmentCache is default enabled.
+        )
     }
- 
-    func testUnloadedClient() async throws {
-        XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
-        {
-            error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.configurationNotLoaded)
-        };
-    }
-
-    func testBadFlagKey() async throws {
+    
+    func testLogsDuplicateAssignmentsWithoutCache() async throws {
+        // Disable the assignment cache.
+        eppoClient = EppoClient("mock-api-key",
+                    host: "http://localhost:4001",
+                    assignmentLogger: loggerSpy.logger,
+                    assignmentCache: nil)
         try await eppoClient.load(httpClient: EppoMockHttpClient());
 
-        XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
-        {
-            error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.flagConfigNotFound)
-        };
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+
+        XCTAssertEqual(loggerSpy.logCount, 2, "Should log twice since there is no cache.")
     }
 
-    func testLogger() async throws {
+    func testDoesNotLogDuplicateAssignmentsWithCache() async throws {
         try await eppoClient.load(httpClient: EppoMockHttpClient());
+        
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
 
-        let assignment = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
-        XCTAssertEqual(assignment, "red")
-        XCTAssertTrue(loggerSpy.wasCalled)
-        if let lastAssignment = loggerSpy.lastAssignment {
-            XCTAssertEqual(lastAssignment.allocation, "allocation-experiment-1")
-            XCTAssertEqual(lastAssignment.experiment, "randomization_algo-allocation-experiment-1")
-            XCTAssertEqual(lastAssignment.subject, "6255e1a72a84e984aed55668")
-        } else {
-            XCTFail("No last assignment was logged.")
-        }
+        XCTAssertEqual(loggerSpy.logCount, 1, "Should log once due to cache hit.")
     }
+    
+    func testLogsForEachUniqueFlag() async throws {
+        try await eppoClient.load(httpClient: EppoMockHttpClient());
+        
+        _ =  try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "new_user_onboarding")
 
-    func testAssignments() async throws {
-        let testFiles = Bundle.module.paths(
-            forResourcesOfType: ".json",
-            inDirectory: "Resources/test-data/assignment-v2"
-        );
-
-        for testFile in testFiles {
-            let caseString = try String(contentsOfFile: testFile);
-            let caseData = caseString.data(using: .utf8)!;
-            let testCase = try JSONDecoder().decode(AssignmentTestCase.self, from: caseData);
-
-            try await eppoClient.load(httpClient: EppoMockHttpClient());
-
-            switch (testCase.valueType) {
-                case "boolean":
-                    let assignments = try testCase.boolAssignments(eppoClient);
-                    let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() }
-                    XCTAssertEqual(assignments, expectedAssignments);
-                case "json":
-                    let assignments = try testCase.jsonAssignments(eppoClient);
-                    let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
-                    XCTAssertEqual(assignments, expectedAssignments);
-                case "numeric":
-                    let assignments = try testCase.numericAssignments(eppoClient);
-                    let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() }
-                    XCTAssertEqual(assignments, expectedAssignments);
-                case "string":
-                    let assignments = try testCase.stringAssignments(eppoClient);
-                    let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
-                    XCTAssertEqual(assignments, expectedAssignments);
-                default:
-                    XCTFail("Unknown value type: \(testCase.valueType)");
+        XCTAssertEqual(loggerSpy.logCount, 2, "Should log 2 times due to changing flags.")
+    }
+    
+    func testLoggingWhenRolloutIncreases() async throws {
+        let mockJson = """
+            {
+                "flags": {
+                    "feature1": {
+                        "subjectShards": 10000,
+                        "typedOverrides": {},
+                        "enabled": true,
+                        "rules": [
+                            {
+                                "allocationKey": "allocation-experiment-1",
+                                "conditions": []
+                            }
+                        ],
+                        "allocations": {
+                            "allocation-experiment-1": {
+                            "percentExposure": 1,
+                            "statusQuoVariationKey": null,
+                            "shippedVariationKey": null,
+                            "variations": [
+                                {
+                                    "name": "control",
+                                    "value": "control",
+                                    "typedValue": "control",
+                                    "shardRange": {
+                                        "start": 0,
+                                        "end": 3333
+                                    },
+                                    "algorithmType": "CONSTANT"
+                                },
+                                {
+                                    "name": "red",
+                                    "value": "red",
+                                    "typedValue": "red",
+                                    "shardRange": {
+                                        "start": 3333,
+                                        "end": 6666
+                                    },
+                                    "algorithmType": "CONSTANT"
+                                },
+                                {
+                                    "name": "green",
+                                    "value": "green",
+                                    "typedValue": "green",
+                                    "shardRange": {
+                                        "start": 6666,
+                                        "end": 10000
+                                    },
+                                    "algorithmType": "CONSTANT"
+                                }
+                            ]
+                            }
+                        }
+                    }
+                }
             }
-        }
+        """
+        let mockHttpClient = EppoJSONAcceptorClient(jsonResponse: mockJson)
+        let eppoClient = EppoClient("your_api_key", host: "http://localhost:4001", assignmentLogger: loggerSpy.logger)
+        // Inject the mock HTTP client
+        try await eppoClient.load(httpClient: mockHttpClient)
+        
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "feature1")
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "feature1")
+        XCTAssertEqual(loggerSpy.logCount, 1, "Should log once with the cache.")
 
-        XCTAssertGreaterThan(testFiles.count, 0);
+        // update the allocation
+        let updatedVariationsJson = """
+            {
+                "flags": {
+                    "feature1": {
+                        "subjectShards": 10000,
+                        "typedOverrides": {},
+                        "enabled": true,
+                        "rules": [
+                            {
+                                "allocationKey": "allocation-experiment-1",
+                                "conditions": []
+                            }
+                        ],
+                        "allocations": {
+                            "allocation-experiment-1": {
+                            "percentExposure": 1,
+                            "statusQuoVariationKey": null,
+                            "shippedVariationKey": null,
+                            "variations": [
+                                {
+                                    "name": "control",
+                                    "value": "control",
+                                    "typedValue": "control",
+                                    "shardRange": {
+                                        "start": 0,
+                                        "end": 0
+                                    },
+                                    "algorithmType": "CONSTANT"
+                                },
+                                {
+                                    "name": "green",
+                                    "value": "green",
+                                    "typedValue": "green",
+                                    "shardRange": {
+                                        "start": 0,
+                                        "end": 10000
+                                    },
+                                    "algorithmType": "CONSTANT"
+                                }
+                            ]
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        // Reload the EppoClient with the updated configuration
+        try await eppoClient.load(httpClient:  EppoJSONAcceptorClient(jsonResponse: updatedVariationsJson))
+
+        // update the allocation
+        let newTreatmentJson = """
+            {
+                "flags": {
+                    "feature1": {
+                        "subjectShards": 10000,
+                        "typedOverrides": {},
+                        "enabled": true,
+                        "rules": [
+                            {
+                                "allocationKey": "allocation-experiment-1",
+                                "conditions": []
+                            }
+                        ],
+                        "allocations": {
+                            "allocation-experiment-1": {
+                            "percentExposure": 1,
+                            "statusQuoVariationKey": null,
+                            "shippedVariationKey": null,
+                            "variations": [
+                                {
+                                    "name": "new-treatment",
+                                    "value": "new-treatment",
+                                    "typedValue": "new-treatment",
+                                    "shardRange": {
+                                        "start": 0,
+                                        "end": 10000
+                                    },
+                                    "algorithmType": "CONSTANT"
+                                }
+                            ]
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        // Reload the EppoClient with the updated configuration
+        try await eppoClient.load(httpClient: EppoJSONAcceptorClient(jsonResponse: newTreatmentJson))
+
+
+        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "feature1")
+        XCTAssertEqual(loggerSpy.logCount, 2, "Should log again since the allocation changed.")
+
     }
 }


### PR DESCRIPTION
## motivation

The assignment cache in the javascript eco-system is useful for preventing duplicate assignment logging events and saving our customers' compute and storage cost.

* eppo javascript commons implementation - https://github.com/Eppo-exp/js-client-sdk-common/pull/25
* https://docs.geteppo.com/sdks/client-sdks/javascript#avoiding-duplicated-assignment-logs

## description

Client SDKs are all tied to a single subject - as such we can afford to implement a non-expiring cache.

Adds an interface of `AssignmentCache` and an implementation of `InMemoryAssignmentCache` using dictionaries. This will be useful for removing duplicate assignments **_within a user session_**. Further refinements can be added to persist this cache on disk to make it remove duplicates across sessions.

## testing

1. Unit tests for the cache class
2. Augmented eppo client tests with a focus on avoiding logging assignment logs. Verify that the cache key, and changes to the configuration, correctly log.