### PR TITLE
Add ConfigurationStorage and ConfigurationRequester and refactor usag…

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "OHHTTPStubs",
+        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs",
+        "state": {
+          "branch": null,
+          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+          "version": "9.1.0"
+        }
+      },
+      {
         "package": "Semver",
         "repositoryURL": "https://github.com/ddddxxx/Semver",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ddddxxx/Semver", from: "0.2.1")
+        .package(url: "https://github.com/ddddxxx/Semver", from: "0.2.1"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs", .upToNextMajor(from: "9.0.0"))
+        
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -30,7 +32,11 @@ let package = Package(
         ),
         .testTarget(
             name: "eppo-flagging-tests",
-            dependencies: ["eppo-flagging"],
+            dependencies: [
+                "eppo-flagging",
+                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
+            ],
             path: "./Tests/eppo",
             resources: [
                 .copy("Resources")

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -25,7 +25,12 @@ class ConfigurationRequester {
         self.httpClient = httpClient
     }
 
-    public static func decodeRACConfig(from jsonString: String) throws -> RACConfig {
+    public func fetchConfigurations() async throws -> RACConfig {
+        let (urlData, _) = try await httpClient.get(RAC_CONFIG_URL);
+        return try ConfigurationRequester.decodeRACConfig(from: String(data: urlData, encoding: .utf8) ?? "");    
+    }
+
+    internal static func decodeRACConfig(from jsonString: String) throws -> RACConfig {
         do {
             guard let jsonData = jsonString.data(using: .utf8) else {
                 throw ConfigurationRequesterError.invalidJSON("Cannot be encoded into UTF-8")
@@ -54,10 +59,5 @@ class ConfigurationRequester {
         } catch let error {
             throw ConfigurationRequesterError.invalidJSON("JSON cannot be parsed: \(error.localizedDescription)")
         }
-    }
-
-    public func fetchConfigurations() async throws -> RACConfig {
-        let (urlData, _) = try await httpClient.get(RAC_CONFIG_URL);
-        return try ConfigurationRequester.decodeRACConfig(from: String(data: urlData, encoding: .utf8) ?? "");    
     }
 }

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -1,0 +1,63 @@
+import Foundation;
+
+let RAC_CONFIG_URL = "/api/randomized_assignment/v3/config"
+
+enum ConfigurationRequesterError: Error, CustomNSError {
+    case invalidJSON(String)
+    case parsingError(String)
+
+    static var errorDomain: String { return "ConfigurationRequesterError" }
+    
+        var errorCode: Int {
+        switch self {
+        case .invalidJSON:
+            return 100 
+        case .parsingError:
+            return 101
+        }
+    }
+}
+
+class ConfigurationRequester {
+    private let httpClient: EppoHttpClient;
+
+    public init(httpClient: EppoHttpClient) {
+        self.httpClient = httpClient
+    }
+
+    public static func decodeRACConfig(from jsonString: String) throws -> RACConfig {
+        do {
+            guard let jsonData = jsonString.data(using: .utf8) else {
+                throw ConfigurationRequesterError.invalidJSON("Cannot be encoded into UTF-8")
+            }
+
+            // Attempt to validate JSON structure
+            do {
+                _ = try JSONSerialization.jsonObject(with: jsonData, options: [])
+            } catch let error {
+                throw ConfigurationRequesterError.invalidJSON("Invalid JSON: \(error.localizedDescription)")
+            }
+
+            // Attempt to decode the JSON into RACConfig
+            return try JSONDecoder().decode(RACConfig.self, from: jsonData)
+        } catch let error as DecodingError {
+            let specificError: String
+            switch error {
+            case .typeMismatch(_, let context), .valueNotFound(_, let context), .keyNotFound(_, let context):
+                specificError = "Parsing error: \(context.debugDescription)"
+            case .dataCorrupted(let context):
+                specificError = "Data corrupted: \(context.debugDescription)"
+            default:
+                specificError = "Unknown parsing error"
+            }
+            throw ConfigurationRequesterError.parsingError(specificError)
+        } catch let error {
+            throw ConfigurationRequesterError.invalidJSON("JSON cannot be parsed: \(error.localizedDescription)")
+        }
+    }
+
+    public func fetchConfigurations() async throws -> RACConfig {
+        let (urlData, _) = try await httpClient.get(RAC_CONFIG_URL);
+        return try ConfigurationRequester.decodeRACConfig(from: String(data: urlData, encoding: .utf8) ?? "");    
+    }
+}

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -1,0 +1,25 @@
+class ConfigurationStore {
+    private let requester: ConfigurationRequester;
+    private var flagConfigs: RACConfig?
+
+    public init(requester: ConfigurationRequester) {
+        self.requester = requester;
+        self.flagConfigs = RACConfig(flags: [:])
+    }
+
+    public func fetchAndStoreConfigurations() async throws {
+        self.flagConfigs = try await self.requester.fetchConfigurations();
+    }
+
+    public func getConfiguration(flagKey: String) -> FlagConfig? {
+        return flagConfigs?.flags[flagKey];
+    }
+
+    public func setConfiguration(flagKey: String, config: FlagConfig) {
+        flagConfigs?.flags[flagKey] = config
+    }
+
+    public func isInitialized() -> Bool {
+        return flagConfigs?.flags.isEmpty == false
+    }
+}

--- a/Sources/eppo/EppoHttpClient.swift
+++ b/Sources/eppo/EppoHttpClient.swift
@@ -27,12 +27,20 @@ public class NetworkEppoHttpClient : EppoHttpClient {
     }
 
     public func get(_ path: String) async throws -> (Data, URLResponse) {
-        var urlString = self.baseURL + path
-        urlString += "?sdkName=ios";
-        urlString += "&sdkVersion=" + sdkVersion;
-        urlString += "&apiKey=" + self.apiKey;
+        var components = URLComponents(string: self.baseURL)
 
-        guard let url = URL(string: urlString) else {
+        // Assuming `path` does not start with a "/", append it conditionally
+        components?.path += path
+
+        // Set up the query items
+        let queryItems = [
+            URLQueryItem(name: "sdkName", value: "ios"),
+            URLQueryItem(name: "sdkVersion", value: sdkVersion),
+            URLQueryItem(name: "apiKey", value: self.apiKey)
+        ]
+        components?.queryItems = queryItems
+
+        guard let url = components?.url else {
             throw Errors.invalidURL;
         }
 

--- a/Sources/eppo/EppoHttpClient.swift
+++ b/Sources/eppo/EppoHttpClient.swift
@@ -5,13 +5,37 @@ public enum EppoHttpClientErrors : Error {
 }
 
 public protocol EppoHttpClient {
-    func get(_ url: URL) async throws -> (Data, URLResponse);
+    func get(_ path: String) async throws -> (Data, URLResponse);
 }
 
 public class NetworkEppoHttpClient : EppoHttpClient {
-    public init() {}
+    private let baseURL: String
+    private let apiKey: String
+    private let sdkName: String
+    private let sdkVersion: String
 
-    public func get(_ url: URL) async throws -> (Data, URLResponse) {
+    public init(
+        baseURL: String,
+        apiKey: String,
+        sdkName: String,
+        sdkVersion: String
+    ) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.sdkName = sdkName
+        self.sdkVersion = sdkVersion
+    }
+
+    public func get(_ path: String) async throws -> (Data, URLResponse) {
+        var urlString = self.baseURL + path
+        urlString += "?sdkName=ios";
+        urlString += "&sdkVersion=" + sdkVersion;
+        urlString += "&apiKey=" + self.apiKey;
+
+        guard let url = URL(string: urlString) else {
+            throw Errors.invalidURL;
+        }
+
         return try await URLSession.shared.data(from: url);
     }
 }

--- a/Sources/eppo/dto/Allocation.swift
+++ b/Sources/eppo/dto/Allocation.swift
@@ -1,4 +1,4 @@
-public struct Allocation: Decodable {
+struct Allocation: Decodable {
     var percentExposure: Float;
     var variations: [Variation];
 }

--- a/Sources/eppo/dto/FlagConfig.swift
+++ b/Sources/eppo/dto/FlagConfig.swift
@@ -1,4 +1,4 @@
-public class FlagConfig : Decodable {
+public struct FlagConfig : Decodable {
     var subjectShards: Int;
     var enabled: Bool;
     var typedOverrides: [String: EppoValue];

--- a/Sources/eppo/dto/OperatorType.swift
+++ b/Sources/eppo/dto/OperatorType.swift
@@ -1,4 +1,4 @@
-public enum OperatorType : String, Decodable {
+enum OperatorType : String, Decodable {
     case Matches = "MATCHES"
     case GreaterThanEqualTo = "GTE"
     case GreaterThan = "GT"

--- a/Sources/eppo/dto/RAC.swift
+++ b/Sources/eppo/dto/RAC.swift
@@ -1,0 +1,3 @@
+public struct RACConfig : Decodable {
+    var flags: [String : FlagConfig];
+}

--- a/Sources/eppo/dto/ShardRange.swift
+++ b/Sources/eppo/dto/ShardRange.swift
@@ -1,4 +1,4 @@
-public struct ShardRange : Decodable {
+struct ShardRange : Decodable {
     var start: Int;
     var end: Int;
 }

--- a/Tests/eppo/ConfigurationRequesterTests.swift
+++ b/Tests/eppo/ConfigurationRequesterTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import eppo_flagging
+
+class ConfigurationRequesterTests: XCTestCase {
+    var httpClientMock: EppoHttpClientMock!
+    var configurationRequester: ConfigurationRequester!
+
+    override func setUp() {
+        super.setUp()
+        httpClientMock = EppoHttpClientMock()
+        configurationRequester = ConfigurationRequester(httpClient: httpClientMock)
+    }
+
+    override func tearDown() {
+        httpClientMock = nil
+        configurationRequester = nil
+        super.tearDown()
+    }
+
+    func testDecodeRACConfig_ValidRACConfigJSON() throws {
+        let jsonString = """
+        {
+            "flags": {
+                "feature1": {
+                    "enabled": true,
+                    "subjectShards": 1,
+                    "typedOverrides": {},
+                    "rules": [],
+                    "allocations": {}
+                }
+            }
+        }
+        """
+        let racConfig = try ConfigurationRequester.decodeRACConfig(from: jsonString)
+        XCTAssertTrue(racConfig.flags.keys.contains("feature1"), "Decoded RACConfig should contain 'feature1'")
+    }
+
+    func testDecodeRACConfig_MissingRequiredKeyJSON() throws {
+        let jsonString = """
+        {
+            "flags": {
+                "feature1": {
+                    "enabled": true
+                }
+            }
+        }
+        """
+        XCTAssertThrowsError(try ConfigurationRequester.decodeRACConfig(from: jsonString)) { error in
+            guard let error = error as NSError? else {
+                XCTFail("Error should be of type NSError")
+                return
+            }
+            XCTAssertEqual(error.domain, ConfigurationRequesterError.errorDomain)
+            XCTAssertEqual(error.code, 101)
+        }
+    }
+
+    func testDecodeRACConfig_InvalidJSON() {
+        let jsonString = "Invalid JSON"
+        XCTAssertThrowsError(try ConfigurationRequester.decodeRACConfig(from: jsonString)) { error in
+            guard let error = error as NSError? else {
+                XCTFail("Error should be of type NSError")
+                return
+            }
+            XCTAssertEqual(error.domain, ConfigurationRequesterError.errorDomain)
+            XCTAssertEqual(error.code, 100)
+        }
+    }
+}
+
+class EppoHttpClientMock: EppoHttpClient {
+    var getCompletionResult: (Data?, Error?)?
+
+    func get(_ url: String) async throws -> (Data, URLResponse) {
+        if let error = getCompletionResult?.1 {
+            throw error
+        }
+        return (getCompletionResult?.0 ?? Data(), URLResponse())
+    }
+}

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import eppo_flagging
+
+final class ConfigurationStoreTests: XCTestCase {
+    var configurationStore: ConfigurationStore!
+    var mockRequester: ConfigurationRequester!
+    
+    let emptyFlagConfig = FlagConfig(subjectShards: 0, enabled: false, typedOverrides: [:], rules: [], allocations: [:])
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockRequester = ConfigurationRequester(httpClient: EppoHttpClientMock())
+        configurationStore = ConfigurationStore(requester: mockRequester)
+    }
+    
+    func testSetAndGetConfiguration() throws {
+        configurationStore.setConfiguration(flagKey: "testFlag", config: emptyFlagConfig)
+        
+        XCTAssertEqual(configurationStore.getConfiguration(flagKey: "testFlag")?.enabled, emptyFlagConfig.enabled)
+    }
+    
+    func testIsInitialized() async throws {
+        XCTAssertFalse(configurationStore.isInitialized(), "Store should not be initialized before fetching configurations")
+        
+        configurationStore.setConfiguration(flagKey: "testFlag", config: emptyFlagConfig)
+        
+        XCTAssertTrue(configurationStore.isInitialized(), "Store should be initialized after fetching configurations")
+    }
+}


### PR DESCRIPTION
…e through it (FF-1943)

## observation

the ios sdk had tightly coupled: 

1. requests to the eppo cdn
2. json parsing

In the interest of its increasing prominence I wanted to invest in improved testing and knowledge of canonical swift patterns.

## changes

* adds `ConfigurationRequester` for interacting with the eppo cdn - common pattern among sdks
* adds `ConfigurationStorage` for maintaining the parsed flag objects
* unit tests for both new classes
* `OHHTTPStubs` testing library to mock network requests