### PR TITLE
Update to UFC public APIs; bump to version 3.0.0 (FF-1950)

### DIFF
--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,6 +1,6 @@
 import Foundation;
 
-public let version = "1.0.1"
+public let version = "3.0.0"
 
 public struct FlagConfigJSON : Decodable {
     var flags: [String : FlagConfig];
@@ -28,7 +28,7 @@ public class EppoClient {
     }
 
     public init(
-        _ apiKey: String,
+        apiKey: String,
         host: String = "https://fscdn.eppo.cloud",
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache()
@@ -52,52 +52,68 @@ public class EppoClient {
         let (urlData, _) = try await httpClient.get(url);
         self.flagConfigs = try JSONDecoder().decode(FlagConfigJSON.self, from: urlData);
     }
-    
-    public func getAssignment(
-        _ subjectKey: String,
-        _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes) throws -> String?
-    {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, false)?.stringValue()
-    }
 
     public func getBoolAssignment(
-        _ subjectKey: String,
-        _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> Bool?
+        flagKey: String,
+        subjectKey: String,
+        subjectAttributes: SubjectAttributes = SubjectAttributes(),
+        defaultValue: Bool) throws -> Bool?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.boolValue()
+        return try getInternalAssignment(
+            flagKey: flagKey, 
+            subjectKey: subjectKey, 
+            subjectAttributes: subjectAttributes, 
+            useTypedVariationValue: true
+        )?.boolValue()
     }
     
     public func getJSONStringAssignment(
-        _ subjectKey: String,
-        _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> String?
+        flagKey: String,
+        subjectKey: String,
+        subjectAttributes: SubjectAttributes = SubjectAttributes(),
+        defaultValue: String) throws -> String?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, false)?.stringValue()
+        return try getInternalAssignment(
+            flagKey: flagKey, 
+            subjectKey: subjectKey, 
+            subjectAttributes: subjectAttributes, 
+            useTypedVariationValue: false
+        )?.stringValue()
     }
     
     public func getNumericAssignment(
-        _ subjectKey: String,
-        _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> Double?
+        flagKey: String,
+        subjectKey: String,
+        subjectAttributes: SubjectAttributes = SubjectAttributes(),
+        defaultValue: Double) throws -> Double?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.doubleValue()
+        return try getInternalAssignment(
+            flagKey: flagKey, 
+            subjectKey: subjectKey, 
+            subjectAttributes: subjectAttributes, 
+            useTypedVariationValue: true
+        )?.doubleValue()
     }
     
     public func getStringAssignment(
-        _ subjectKey: String,
-        _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes = SubjectAttributes()) throws -> String?
+        flagKey: String,
+        subjectKey: String,
+        subjectAttributes: SubjectAttributes = SubjectAttributes(),
+        defaultValue: String = "") throws -> String?
     {
-        return try getInternalAssignment(subjectKey, flagKey, subjectAttributes, true)?.stringValue()
+        return try getInternalAssignment(
+            flagKey: flagKey, 
+            subjectKey: subjectKey, 
+            subjectAttributes: subjectAttributes, 
+            useTypedVariationValue: true
+        )?.stringValue()
     }
     
     private func getInternalAssignment(
-        _ subjectKey: String,
-        _ flagKey: String,
-        _ subjectAttributes: SubjectAttributes,
-        _ useTypedVariationValue: Bool) throws -> EppoValue?
+        flagKey: String,
+        subjectKey: String,
+        subjectAttributes: SubjectAttributes,
+        useTypedVariationValue: Bool) throws -> EppoValue?
     {
         try self.validate();
 

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -57,56 +57,56 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Bool) throws -> Bool?
+        defaultValue: Bool) throws -> Bool
     {
         return try getInternalAssignment(
             flagKey: flagKey, 
             subjectKey: subjectKey, 
             subjectAttributes: subjectAttributes, 
             useTypedVariationValue: true
-        )?.boolValue()
+        )?.boolValue() ?? defaultValue
     }
     
     public func getJSONStringAssignment(
         flagKey: String,
         subjectKey: String,
-        subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: String) throws -> String?
+        subjectAttributes: SubjectAttributes,
+        defaultValue: String) throws -> String
     {
         return try getInternalAssignment(
             flagKey: flagKey, 
             subjectKey: subjectKey, 
             subjectAttributes: subjectAttributes, 
             useTypedVariationValue: false
-        )?.stringValue()
+        )?.stringValue() ?? defaultValue
     }
     
     public func getNumericAssignment(
         flagKey: String,
         subjectKey: String,
-        subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Double) throws -> Double?
+        subjectAttributes: SubjectAttributes,
+        defaultValue: Double) throws -> Double
     {
         return try getInternalAssignment(
             flagKey: flagKey, 
             subjectKey: subjectKey, 
             subjectAttributes: subjectAttributes, 
             useTypedVariationValue: true
-        )?.doubleValue()
+        )?.doubleValue() ?? defaultValue
     }
     
     public func getStringAssignment(
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: String = "") throws -> String?
+        defaultValue: String) throws -> String
     {
         return try getInternalAssignment(
             flagKey: flagKey, 
             subjectKey: subjectKey, 
             subjectAttributes: subjectAttributes, 
             useTypedVariationValue: true
-        )?.stringValue()
+        )?.stringValue() ?? defaultValue
     }
     
     private func getInternalAssignment(

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -99,6 +99,7 @@ struct AssignmentTestCase : Decodable {
                 try client.getJSONStringAssignment(
                     flagKey: self.experiment,
                     subjectKey: $0,
+                    subjectAttributes: SubjectAttributes(),
                     defaultValue: ""
                 );
             })
@@ -124,6 +125,7 @@ struct AssignmentTestCase : Decodable {
                 try client.getNumericAssignment(
                     flagKey: self.experiment,
                     subjectKey: $0,
+                    subjectAttributes: SubjectAttributes(),
                     defaultValue: 0
                 );
             })

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -232,19 +232,19 @@ final class eppoClientTests: XCTestCase {
            switch (testCase.valueType) {
            case "boolean":
                let assignments = try testCase.boolAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() }
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() ?? false }
                XCTAssertEqual(assignments, expectedAssignments);
            case "json":
                let assignments = try testCase.jsonAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() ?? "" }
                XCTAssertEqual(assignments, expectedAssignments);
            case "numeric":
                let assignments = try testCase.numericAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() }
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() ?? 0 }
                XCTAssertEqual(assignments, expectedAssignments);
            case "string":
                let assignments = try testCase.stringAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
+               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() ?? "" }
                XCTAssertEqual(assignments, expectedAssignments);
            default:
                XCTFail("Unknown value type: \(testCase.valueType)");

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -72,8 +72,8 @@ struct AssignmentTestCase : Decodable {
             });
         }
 
-        if self.subjects != nil {
-            return try self.subjects!.map({ try client.getBoolAssignment(
+        if let subjects = self.subjects {
+            return try subjects.map({ try client.getBoolAssignment(
                 flagKey: self.experiment,
                 subjectKey: $0,
                 defaultValue: false); })
@@ -94,8 +94,8 @@ struct AssignmentTestCase : Decodable {
             });
         }
 
-        if self.subjects != nil {
-            return try self.subjects!.map({
+        if let subjects = self.subjects {
+            return try subjects.map({
                 try client.getJSONStringAssignment(
                     flagKey: self.experiment,
                     subjectKey: $0,
@@ -120,8 +120,8 @@ struct AssignmentTestCase : Decodable {
             });
         }
 
-        if self.subjects != nil {
-            return try self.subjects!.map({
+        if let subjects = self.subjects {
+            return try subjects.map({
                 try client.getNumericAssignment(
                     flagKey: self.experiment,
                     subjectKey: $0,
@@ -146,8 +146,8 @@ struct AssignmentTestCase : Decodable {
             });
         }
 
-        if self.subjects != nil {
-            return try self.subjects!.map({
+        if let subjects = self.subjects {
+            return try subjects.map({
                 try client.getStringAssignment(
                     flagKey: self.experiment,
                     subjectKey: $0,

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -140,13 +140,21 @@ struct AssignmentTestCase : Decodable {
                 try client.getStringAssignment(
                     flagKey: self.experiment,
                     subjectKey: $0.subjectKey,
-                    subjectAttributes: $0.subjectAttributes
+                    subjectAttributes: $0.subjectAttributes,
+                    defaultValue: ""
                 )
             });
         }
 
         if self.subjects != nil {
-            return try self.subjects!.map({ try client.getStringAssignment(flagKey: self.experiment, subjectKey: $0); })
+            return try self.subjects!.map({
+                try client.getStringAssignment(
+                    flagKey: self.experiment,
+                    subjectKey: $0,
+                    subjectAttributes: SubjectAttributes(),
+                    defaultValue: ""
+                );
+            })
         }
 
         return [];
@@ -166,7 +174,11 @@ final class eppoClientTests: XCTestCase {
    }
    
    func testUnloadedClient() async throws {
-       XCTAssertThrowsError(try eppoClient.getStringAssignment(flagKey: "badFlagRising", subjectKey: "abc"))
+       XCTAssertThrowsError(try eppoClient.getStringAssignment(
+            flagKey: "badFlagRising",
+            subjectKey: "abc",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: ""))
        {
            error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.configurationNotLoaded)
        };
@@ -175,7 +187,11 @@ final class eppoClientTests: XCTestCase {
    func testBadFlagKey() async throws {
        try await eppoClient.load(httpClient: EppoMockHttpClient());
        
-       XCTAssertThrowsError(try eppoClient.getStringAssignment(flagKey: "badFlagRising", subjectKey: "def"))
+       XCTAssertThrowsError(try eppoClient.getStringAssignment(
+            flagKey: "badFlagRising",
+            subjectKey: "def",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: ""))
        {
            error in XCTAssertEqual(error as! EppoClient.Errors, EppoClient.Errors.flagConfigNotFound)
        };
@@ -184,7 +200,11 @@ final class eppoClientTests: XCTestCase {
    func testLogger() async throws {
        try await eppoClient.load(httpClient: EppoMockHttpClient());
        
-       let assignment = try eppoClient.getStringAssignment(flagKey: "randomization_algo", subjectKey: "6255e1a72a84e984aed55668")
+       let assignment = try eppoClient.getStringAssignment(
+            flagKey: "randomization_algo",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
        XCTAssertEqual(assignment, "red")
        XCTAssertTrue(loggerSpy.wasCalled)
        if let lastAssignment = loggerSpy.lastAssignment {
@@ -259,8 +279,16 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
                     assignmentCache: nil)
         try await eppoClient.load(httpClient: EppoMockHttpClient());
 
-        _ = try eppoClient.getStringAssignment(flagKey: "randomization_algo", subjectKey: "6255e1a72a84e984aed55668")
-        _ = try eppoClient.getStringAssignment(flagKey: "randomization_algo", subjectKey: "6255e1a72a84e984aed55668")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "randomization_algo",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "randomization_algo",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
 
         XCTAssertEqual(loggerSpy.logCount, 2, "Should log twice since there is no cache.")
     }
@@ -268,8 +296,16 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
     func testDoesNotLogDuplicateAssignmentsWithCache() async throws {
         try await eppoClient.load(httpClient: EppoMockHttpClient());
         
-        _ = try eppoClient.getStringAssignment(flagKey: "randomization_algo", subjectKey: "6255e1a72a84e984aed55668")
-        _ = try eppoClient.getStringAssignment(flagKey: "randomization_algo", subjectKey: "6255e1a72a84e984aed55668")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "randomization_algo",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "randomization_algo",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
 
         XCTAssertEqual(loggerSpy.logCount, 1, "Should log once due to cache hit.")
     }
@@ -277,8 +313,16 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
     func testLogsForEachUniqueFlag() async throws {
         try await eppoClient.load(httpClient: EppoMockHttpClient());
         
-        _ =  try eppoClient.getStringAssignment(flagKey: "randomization_algo", subjectKey: "6255e1a72a84e984aed55668")
-        _ = try eppoClient.getStringAssignment(flagKey: "new_user_onboarding", subjectKey: "6255e1a72a84e984aed55668")
+        _ =  try eppoClient.getStringAssignment(
+            flagKey: "randomization_algo",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "new_user_onboarding",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
 
         XCTAssertEqual(loggerSpy.logCount, 2, "Should log 2 times due to changing flags.")
     }
@@ -345,8 +389,16 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
         // Inject the mock HTTP client
         try await eppoClient.load(httpClient: mockHttpClient)
         
-        _ = try eppoClient.getStringAssignment(flagKey: "feature1", subjectKey: "6255e1a72a84e984aed55668")
-        _ = try eppoClient.getStringAssignment(flagKey: "feature1", subjectKey: "6255e1a72a84e984aed55668")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "feature1",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "feature1",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
         XCTAssertEqual(loggerSpy.logCount, 1, "Should log once with the cache.")
 
         // update the allocation
@@ -440,7 +492,11 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
         try await eppoClient.load(httpClient: EppoJSONAcceptorClient(jsonResponse: newTreatmentJson))
 
 
-        _ = try eppoClient.getStringAssignment(flagKey: "feature1", subjectKey: "6255e1a72a84e984aed55668")
+        _ = try eppoClient.getStringAssignment(
+            flagKey: "feature1",
+            subjectKey: "6255e1a72a84e984aed55668",
+            subjectAttributes: SubjectAttributes(),
+            defaultValue: "")
         XCTAssertEqual(loggerSpy.logCount, 2, "Should log again since the allocation changed.")
 
     }


### PR DESCRIPTION
## Context

The upcoming UFC introduces breaking API changes. The work to migrate the ios sdk is being collected in `lr/ff-1938/ufc` - after all sub-tasks are completed (merged into it), it will be merged to the main branch as version `3.0.0`.

Several decisions have been made regarding the public API. The format will generally follow:

```
#  all arguments mandatory: keeps key and attributes together; changes the order compared to today.
getStringAssignment('new-checkout-page', user.id, userAttributes, 'off')
```

The rationale being:

* the flag key is the most obvious identifier for the application code - developers will want to see this first in order to determine the purpose
* keeps subject related arguments closer together
* adds a new default value parameter

## Changes in this PR

* removes `getAssignment` - it was previously deprecated
* updates argument ordering to match decision above
* replaces `argument label omission` style with `required argument label` - I believe this increases clarity when there are consecutive same-type parameters (such as `String, String`). A mistake here has large consequences that we want our users to avoid. One of our unit tests had this 🐛 There are [other libraries](https://docs.launchdarkly.com/sdk/client-side/ios) that also use this pattern.