### PR TITLE
Allow a single process to perform network fetching and updating configuration cache (FF-2238)

### DIFF
--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -10,12 +10,12 @@ class ConfigurationStore {
         self.requester = requester
         self.flagConfigs = RACConfig(flags: [:])
     }
-    
+
     public func fetchAndStoreConfigurations() async throws {
         let config = try await self.requester.fetchConfigurations()
         self.setConfigurations(config: config)
     }
-    
+
     // Get the configuration for a given flag key in a thread-safe manner.
     //
     // The use of a syncQueue ensures that this read operation is thread-safe and doesn't cause
@@ -26,11 +26,11 @@ class ConfigurationStore {
         }
     }
     
-    //   Set the configurations in a thread-safe manner.
+    // Set the configurations in a thread-safe manner.
     //
-    //   The use of a barrier ensures that this write operation completes before any other read or write
-    //   operations on the `flagConfigs` can proceed. This guarantees that the configuration state is
-    //   consistent and prevents race conditions where reads could see a partially updated state.
+    // The use of a barrier ensures that this write operation completes before any other read or write
+    // operations on the `flagConfigs` can proceed. This guarantees that the configuration state is
+    // consistent and prevents race conditions where reads could see a partially updated state.
     public func setConfigurations(config: RACConfig) {
         syncQueue.async(flags: .barrier) {
             self.flagConfigs = config

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -1,25 +1,45 @@
-class ConfigurationStore {
-    private let requester: ConfigurationRequester;
-    private var flagConfigs: RACConfig?
+import Foundation
 
+class ConfigurationStore {
+    private let requester: ConfigurationRequester
+    private var flagConfigs: RACConfig?
+    private let syncQueue = DispatchQueue(
+        label: "com.eppo.configurationStoreQueue", attributes: .concurrent)
+    
     public init(requester: ConfigurationRequester) {
-        self.requester = requester;
+        self.requester = requester
         self.flagConfigs = RACConfig(flags: [:])
     }
-
+    
     public func fetchAndStoreConfigurations() async throws {
-        self.flagConfigs = try await self.requester.fetchConfigurations();
+        let config = try await self.requester.fetchConfigurations()
+        self.setConfigurations(config: config)
     }
-
+    
+    // Get the configuration for a given flag key in a thread-safe manner.
+    //
+    // The use of a syncQueue ensures that this read operation is thread-safe and doesn't cause
+    // race conditions where reads could see a partially updated state.
     public func getConfiguration(flagKey: String) -> FlagConfig? {
-        return flagConfigs?.flags[flagKey];
+        return syncQueue.sync {
+            flagConfigs?.flags[flagKey]
+        }
     }
-
-    public func setConfiguration(flagKey: String, config: FlagConfig) {
-        flagConfigs?.flags[flagKey] = config
+    
+    //   Set the configurations in a thread-safe manner.
+    //
+    //   The use of a barrier ensures that this write operation completes before any other read or write
+    //   operations on the `flagConfigs` can proceed. This guarantees that the configuration state is
+    //   consistent and prevents race conditions where reads could see a partially updated state.
+    public func setConfigurations(config: RACConfig) {
+        syncQueue.async(flags: .barrier) {
+            self.flagConfigs = config
+        }
     }
-
+    
     public func isInitialized() -> Bool {
-        return flagConfigs?.flags.isEmpty == false
+        return syncQueue.sync {
+            flagConfigs?.flags.isEmpty == false
+        }
     }
 }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,7 +1,7 @@
 import Foundation;
 
 // todo: make this a build argument (FF-1944)
-let sdkVersion = "1.0.1"
+let sdkVersion = "1.2.1"
 let sdkName = "ios"
 
 // todo: these exported errors could use some work. only ones here that are

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -1,29 +1,43 @@
 import XCTest
+
 @testable import eppo_flagging
 
 final class ConfigurationStoreTests: XCTestCase {
     var configurationStore: ConfigurationStore!
     var mockRequester: ConfigurationRequester!
+    var configs: RACConfig!
     
-    let emptyFlagConfig = FlagConfig(subjectShards: 0, enabled: false, typedOverrides: [:], rules: [], allocations: [:])
+    let emptyFlagConfig = FlagConfig(
+        subjectShards: 0, enabled: false, typedOverrides: [:], rules: [], allocations: [:])
     
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockRequester = ConfigurationRequester(httpClient: EppoHttpClientMock())
         configurationStore = ConfigurationStore(requester: mockRequester)
+        
+        configs = RACConfig(flags: [
+            "testFlag": emptyFlagConfig
+        ])
     }
     
     func testSetAndGetConfiguration() throws {
-        configurationStore.setConfiguration(flagKey: "testFlag", config: emptyFlagConfig)
+        // Pass the RACConfig object to setConfigurations
+        configurationStore.setConfigurations(config: configs)
         
-        XCTAssertEqual(configurationStore.getConfiguration(flagKey: "testFlag")?.enabled, emptyFlagConfig.enabled)
+        XCTAssertEqual(
+            configurationStore.getConfiguration(flagKey: "testFlag")?.enabled, emptyFlagConfig.enabled)
     }
     
     func testIsInitialized() async throws {
-        XCTAssertFalse(configurationStore.isInitialized(), "Store should not be initialized before fetching configurations")
+        XCTAssertFalse(
+            configurationStore.isInitialized(),
+            "Store should not be initialized before fetching configurations")
         
-        configurationStore.setConfiguration(flagKey: "testFlag", config: emptyFlagConfig)
+        configurationStore.setConfigurations(config: configs)
         
-        XCTAssertTrue(configurationStore.isInitialized(), "Store should be initialized after fetching configurations")
+        XCTAssertTrue(
+            configurationStore.isInitialized(),
+            "Store should be initialized after fetching configurations")
     }
+    
 }


### PR DESCRIPTION
## problem

When developers instantiate Eppo's SDK they must manually call the `public func load() async throws` function. They are able to do so from the main thread or any other - the expectation is after it completes that the local cache will be populated.

The recommended approach is to wrap with an async task:

```
@MainActor
class AssignmentObserver : ObservableObject {
    @Published var assignment: String?;
    var eppoClient: EppoClient = EppoClient(EPPO_API_KEY);

    public init() {
        Task {
            do {
                try await eppoClient.load();
                self.assignment = try self.eppoClient.getStringAssignment(
                    "test-user", // identifier to randomize (typically a user id)
                    "ios-test-app-treatment" // the variation to select from
                );
            } catch {
                self.assignment = nil;
            }
        }
    }
}
```

https://docs.geteppo.com/sdks/client-sdks/ios/#3-assign-variations

## observation

Bad memory access was reported in (https://github.com/Eppo-exp/eppo-ios-sdk/issues/23) when setting the `flagConfigs ` attribute.

The root cause of the crash appears to be an unsafe variable assignment.

## changes

* Using a dispatch queue for all access to the underlying configuration cache.
* When writing updated cache values, perform the HTTP request and JSON parsing outside a lock. Use a [dispatch barrier](https://developer.apple.com/documentation/dispatch/dispatch_barrier) to ensure a single access.
* When reading from the cached configuration, chiefly during assignment, use the dispatch queue in `concurrent` access mode to allow parallel reads. However when a write is happening the read will pause until the data structure is updated.

tidy up

* the `setConfiguration` method is not needed - we should never write a single flag at a time, doing so invites stale flags. changing to the plural and updating all flags.