### PR TITLE
Parse UFC API into native models (FF-2311)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,5 @@ test-data:
 	rm -rf $(testDataDir)
 	mkdir -p $(tempDir)
 	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
-	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
-	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	cp -r ${gitDataDir} ${testDataDir}
 	rm -rf ${tempDir}

--- a/Sources/eppo/UniversalFlagConfig.swift
+++ b/Sources/eppo/UniversalFlagConfig.swift
@@ -81,6 +81,17 @@ enum UFC_AlgorithmType: String, Decodable {
     case contextualBandit = "CONTEXTUAL_BANDIT"
 }
 
+enum UFC_RuleConditionOperator: String, Decodable {
+  case lessThan = "LT"
+  case lessThanEqual = "LTE"
+  case greaterThan = "GT"
+  case greaterThanEqual = "GTE"
+  case matches = "MATCHES"
+  case oneOf = "ONE_OF"
+  case notOneOf = "NOT_ONE_OF"
+  case isNull = "IS_NULL"
+}
+
 // models
 
 public struct UFC_Flag : Decodable {
@@ -112,7 +123,7 @@ public struct UFC_Rule : Decodable {
 }
 
 public struct UFC_TargetingRuleCondition : Decodable {
-    let `operator`: String;
+    let `operator`: UFC_RuleConditionOperator;
     let attribute: String;
     let value: EppoValue;
 }

--- a/Sources/eppo/UniversalFlagConfig.swift
+++ b/Sources/eppo/UniversalFlagConfig.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+public struct UniversalFlagConfig : Decodable {
+    let createdAt: Date?;
+    let flags: [String: UFC_Flag];
+    // todo: add bandits
+    
+    static func decodeFromJSON(from jsonString: String) throws -> UniversalFlagConfig {
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            throw UniversalFlagConfigError.notUTF8Encoded("Failed to encode JSON string into UTF-8 data.")
+        }
+
+        let decoder = JSONDecoder()
+        
+        // Set up the date formatter
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"  // Adjusted to include milliseconds
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")  // Use POSIX to avoid unexpected behaviors
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)  // Adjust if your JSON dates are not in GMT
+        
+        // Use the date formatter in the decoder
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        
+        do {
+            return try decoder.decode(UniversalFlagConfig.self, from: jsonData)
+        } catch let error as DecodingError {
+            switch error {
+            case .typeMismatch(_, let context):
+                throw UniversalFlagConfigError.parsingError("Type mismatch: \(context.debugDescription)")
+            case .valueNotFound(_, let context):
+                throw UniversalFlagConfigError.parsingError("Value not found: \(context.debugDescription)")
+            case .keyNotFound(let key, let context):
+                throw UniversalFlagConfigError.parsingError("Key not found: \(key.stringValue) - \(context.debugDescription)")
+            case .dataCorrupted(let context):
+                throw UniversalFlagConfigError.parsingError("Data corrupted: \(context.debugDescription)")
+            default:
+                throw UniversalFlagConfigError.parsingError("JSON parsing error: \(error.localizedDescription)")
+            }
+        } catch {
+            throw UniversalFlagConfigError.parsingError("Unexpected error: \(error.localizedDescription)")
+        }
+    }
+}
+
+// enums
+enum UniversalFlagConfigError: Error, CustomNSError, LocalizedError {
+    case notUTF8Encoded(String)
+    case parsingError(String)
+
+    static var errorDomain: String { return "UniversalFlagConfigError" }
+    
+    var errorCode: Int {
+        switch self {
+        case .notUTF8Encoded:
+            return 100 
+        case .parsingError:
+            return 101
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .notUTF8Encoded(let message):
+            return message
+        case .parsingError(let message):
+            return message
+        }
+    }
+}
+
+enum UFC_VariationType: String, Decodable {
+      case boolean = "BOOLEAN"
+      case integer = "INTEGER"
+      case json = "JSON"
+      case numeric = "NUMERIC"
+      case string = "STRING"    
+}
+
+enum UFC_AlgorithmType: String, Decodable {
+    case constant = "CONSTANT"
+    case contextualBandit = "CONTEXTUAL_BANDIT"
+}
+
+// models
+
+public struct UFC_Flag : Decodable {
+    let key: String;
+    let enabled: Bool;
+    let variationType: UFC_VariationType;
+    let variations: [String: UFC_Variation];
+    let allocations: [UFC_Allocation];
+    let totalShards: Int;
+}
+
+public struct UFC_Variation : Decodable  {
+    let key: String;
+    let value: EppoValue;
+    let algorithmType: UFC_AlgorithmType?
+}
+
+public struct UFC_Allocation : Decodable {
+    let key: String;
+    let rules: [UFC_Rule]?;
+    let startAt: Date?;
+    let endAt: Date?;
+    let splits: [UFC_Split];
+    let doLog: Bool;
+}
+
+public struct UFC_Rule : Decodable {
+    let conditions: [UFC_TargetingRuleCondition];
+}
+
+public struct UFC_TargetingRuleCondition : Decodable {
+    let `operator`: String;
+    let attribute: String;
+    let value: EppoValue;
+}
+
+public struct UFC_Split : Decodable {
+    let variationKey: String;
+    let shards: [UFC_Shard];
+    let extraLogging: [String: String]?
+}
+
+public struct UFC_Shard : Decodable {
+    let salt: String;
+    let ranges: [UFC_Range];
+}
+
+public struct UFC_Range : Decodable {
+    let start: Int;
+    let end: Int;
+}

--- a/Tests/eppo/EppoValueTests.swift
+++ b/Tests/eppo/EppoValueTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+import Foundation
+
+@testable import eppo_flagging
+
+class EppoValueTests: XCTestCase {
+
+    let decoder = JSONDecoder()
+    let jsonKey = "value"
+
+    func testDecodingString() throws {
+        let jsonData = try jsonData(from: #"{"\#(jsonKey)": "testString"}"#)
+        
+        let decodedValue = try decoder.decode([String: EppoValue].self, from: jsonData)
+        XCTAssertEqual(try decodedValue[jsonKey]?.stringValue(), "testString")
+    }
+    
+    func testDecodingInteger() throws {
+        let jsonData = try jsonData(from: #"{"\#(jsonKey)": 123}"#)
+        
+        let decodedValue = try decoder.decode([String: EppoValue].self, from: jsonData)
+        XCTAssertEqual(try decodedValue[jsonKey]?.doubleValue(), 123)
+    }
+    
+    func testDecodingDouble() throws {
+        let jsonData = try jsonData(from: #"{"\#(jsonKey)": 123.456}"#)
+        
+        let decodedValue = try decoder.decode([String: EppoValue].self, from: jsonData)
+        XCTAssertEqual(try decodedValue[jsonKey]?.doubleValue(), 123.456)
+    }
+    
+    func testDecodingArrayOfStrings() throws {
+        let jsonData = try jsonData(from: #"{"\#(jsonKey)": ["one","two","three"]}"#)
+        let decoder = JSONDecoder()
+        
+        let decodedValue = try decoder.decode([String: EppoValue].self, from: jsonData)
+        XCTAssertEqual(try decodedValue[jsonKey]?.arrayValue(), ["one", "two", "three"])
+    }
+
+    private func jsonData(from jsonString: String) throws -> Data {
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            throw NSError(domain: "JSONError", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON string"])
+        }
+        return jsonData
+    }
+}

--- a/Tests/eppo/UniversalFlagConfigTests.swift
+++ b/Tests/eppo/UniversalFlagConfigTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+import Foundation
+
+@testable import eppo_flagging
+
+final class UniversalFlagConfigTest: XCTestCase {
+    var fileURL: URL!
+    var UFCTestJSON: String!
+
+    override func setUp() {
+        super.setUp()
+        fileURL = Bundle.module.url(
+            forResource: "Resources/test-data/ufc/flags-v1.json",
+            withExtension: ""
+        )
+        do {
+            UFCTestJSON = try String(contentsOfFile: fileURL.path)
+        } catch {
+            XCTFail("Error loading test JSON: \(error)")
+        }
+    }
+
+    func testDecodeUFCConfig() {
+        let config = try! UniversalFlagConfig.decodeFromJSON(from: UFCTestJSON)
+        XCTAssertEqual(config.flags.count, 14, "There should be 14 flags present in the JSON test file.")
+        
+        // empty flag
+        let emptyFlag = config.flags.first(where: { $0.key == "empty_flag" })?.value
+        XCTAssertTrue(emptyFlag?.enabled == true, "The 'empty_flag' flag should be enabled.")
+        
+        // disabled flag
+        let disabledFlag = config.flags.first(where: { $0.key == "disabled_flag" })?.value
+        XCTAssertTrue(disabledFlag?.enabled == false, "The 'disabled_flag' flag should be disabled.")
+        
+        // variation type
+        let variationFlag = config.flags.first(where: { $0.key == "numeric_flag" })?.value
+        XCTAssertEqual(variationFlag?.enabled, true, "The 'numeric_flag' flag should be enabled.")
+        XCTAssertEqual(variationFlag?.variationType, UFC_VariationType.numeric, "The 'numeric_flag' flag should have a variation type of 'NUMERIC'.")
+        XCTAssertEqual(variationFlag?.variations.count, 2, "The 'numeric_flag' flag should have 2 variations.")
+        XCTAssertEqual(variationFlag?.variations["e"]?.key, "e", "The 'numeric_flag' flag should have a variation key of 'e'.")
+        XCTAssertEqual(try variationFlag?.variations["e"]?.value.doubleValue(), 2.7182818, "The 'numeric_flag' flag should have a variation value of '100'.")
+
+        // total shards
+        XCTAssertEqual(variationFlag?.totalShards, 10000, "The total shards should be 10000.")
+    }
+
+    // errors
+
+    // todo: add a test for not utf8 encoded values. need to figure out how to implement this.
+
+    func testUnableToDecodeJSON() {
+        let invalidJSON = "invalid_json"
+        XCTAssertThrowsError(try UniversalFlagConfig.decodeFromJSON(from: invalidJSON)) { error in
+            guard let thrownError = error as? UniversalFlagConfigError else {
+                XCTFail("Error should be of type UniversalFlagConfigError")
+                return
+            }
+            XCTAssertEqual(thrownError.errorCode, 101, "Error code should be 101 indicating a JSON parsing issue")
+            XCTAssertEqual(thrownError.localizedDescription, "Data corrupted: The given data was not valid JSON.")
+        }
+    }
+}


### PR DESCRIPTION
## motivation

* SDK is being migrated to the UFC API - my goal is to keep the PRs small so that reviews are quick and engineers can keep their attention fresh.
* 🐛 `value` field can handle incoming integer values to `EppoValue` but not `Double`

```
{
   value: 123.45
}
```

* Base branch continues to be `lr/ff-1938/ufc` not `main`. After all PRs are accepted and tests pass we will merge the entire feature into main.

## changes

* Adds new models for parsing UFC API; these are in parallel with the existing RAC models and have no impact on the production code.
* Fixes bug to allow parsing `Double` to the `EppoValue` class.
* Adds new unit test for `EppoValue`.
* More granular errors returned during json parsing.