### PR TITLE
Add support for getJSONAssignment (FF-1951)

### DIFF
--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -70,7 +70,7 @@ public class EppoClient {
         }
     }
     
-    public func getJSONAssignment(
+    public func getJSONStringAssignment(
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes,

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -105,7 +105,7 @@ public class EppoClient {
         }
     }
     
-    public func getDoubleAssignment(
+    public func getNumericAssignment(
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -105,7 +105,7 @@ public class EppoClient {
         }
     }
     
-    public func getNumericAssignment(
+    public func getDoubleAssignment(
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -70,20 +70,20 @@ public class EppoClient {
         }
     }
     
-    // todo: add back when supporting JSON
-//    public func getJSONAssignment(
-//        flagKey: String,
-//        subjectKey: String,
-//        subjectAttributes: SubjectAttributes,
-//        defaultValue: [String: EppoValue]) throws -> [String: EppoValue]
-//    {
-//        return try getInternalAssignment(
-//            flagKey: flagKey, 
-//            subjectKey: subjectKey, 
-//            subjectAttributes: subjectAttributes
-//        )?.variation?.value?.objectValue() ?? defaultValue
-//    }
-//    
+    public func getJSONAssignment(
+        flagKey: String,
+        subjectKey: String,
+        subjectAttributes: SubjectAttributes,
+        defaultValue: String) throws -> String
+    {
+        return try getInternalAssignment(
+            flagKey: flagKey, 
+            subjectKey: subjectKey, 
+            subjectAttributes: subjectAttributes,
+            expectedVariationType: UFC_VariationType.json
+        )?.variation?.value.getStringValue() ?? defaultValue
+    }
+    
     
     public func getIntegerAssignment(
         flagKey: String,

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -196,7 +196,13 @@ public class FlagEvaluator {
             // Handle the nil case, perhaps throw an error or return a default value
             return false
         }
-        
+
+        // Safely unwrap attributeValue for further use
+        guard let value = attributeValue else {
+            // Handle the nil case, perhaps throw an error or return a default value
+            return false
+        }
+
         do {
             switch condition.operator {
             case .greaterThanEqual, .greaterThan, .lessThanEqual, .lessThan:
@@ -234,7 +240,7 @@ public class FlagEvaluator {
                             throw Errors.UnexpectedValue
                         }
                     }
-                } catch {
+                } catch let e {
                     // If stringValue() or doubleValue() throws, or Semver creation fails
                     return false
                 }

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -190,19 +190,13 @@ public class FlagEvaluator {
             // Any check other than IS NULL should fail if the attribute value is null
             return false
         }
+
+        // Safely unwrap attributeValue for further use
+        guard let value = attributeValue else {
+            // Handle the nil case, perhaps throw an error or return a default value
+            return false
+        }
         
-        // Safely unwrap attributeValue for further use
-        guard let value = attributeValue else {
-            // Handle the nil case, perhaps throw an error or return a default value
-            return false
-        }
-
-        // Safely unwrap attributeValue for further use
-        guard let value = attributeValue else {
-            // Handle the nil case, perhaps throw an error or return a default value
-            return false
-        }
-
         do {
             switch condition.operator {
             case .greaterThanEqual, .greaterThan, .lessThanEqual, .lessThan:

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -240,7 +240,7 @@ public class FlagEvaluator {
                             throw Errors.UnexpectedValue
                         }
                     }
-                } catch let e {
+                } catch {
                     // If stringValue() or doubleValue() throws, or Semver creation fails
                     return false
                 }

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -102,7 +102,7 @@ final class eppoClientTests: XCTestCase {
                         "FlagKey: \(testCase.flag), SubjectKey: \(subject.subjectKey)"
                     )
                 case UFC_VariationType.json:
-                    let assignment = try? eppoClient.getJSONAssignment(
+                    let assignment = try? eppoClient.getJSONStringAssignment(
                         flagKey: testCase.flag,
                         subjectKey: subject.subjectKey,
                         subjectAttributes: subject.subjectAttributes,

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -102,10 +102,14 @@ final class eppoClientTests: XCTestCase {
                         "FlagKey: \(testCase.flag), SubjectKey: \(subject.subjectKey)"
                     )
                 case UFC_VariationType.json:
-                    print("json not supported")
-                    //               let assignments = try testCase.jsonAssignments(eppoClient);
-                    // //               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() ?? "" }
-                    // //               XCTAssertEqual(assignments, expectedAssignments);
+                    let assignment = try? eppoClient.getJSONAssignment(
+                        flagKey: testCase.flag,
+                        subjectKey: subject.subjectKey,
+                        subjectAttributes: subject.subjectAttributes,
+                        defaultValue: testCase.defaultValue.getStringValue()
+                    );
+                    let expectedAssignment = try? subject.assignment.getStringValue()
+                    XCTAssertEqual(assignment, expectedAssignment)
                 case UFC_VariationType.integer:
                     let assignment = try? eppoClient.getIntegerAssignment(
                         flagKey: testCase.flag,


### PR DESCRIPTION
## motivation

Add support for the `json` variation type. Given we cannot know what json parsing library our customers wish to use, we have decided its safer to return the stringified value directly and let them handle as needed.

## description

Add  `getJSONAssignment` that returns a `String`