### PR TITLE
Add support for 3 new data tests (specifically adding and subjectKey implicitly as "id" subject attribute)

### DIFF
--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -96,7 +96,11 @@ final class eppoClientTests: XCTestCase {
                         defaultValue: testCase.defaultValue.getBoolValue()
                     );
                     let expectedAssignment = try? subject.assignment.getBoolValue()
-                    XCTAssertEqual(assignment, expectedAssignment)
+                    XCTAssertEqual(
+                        assignment,
+                        expectedAssignment,
+                        "FlagKey: \(testCase.flag), SubjectKey: \(subject.subjectKey)"
+                    )
                 case UFC_VariationType.json:
                     print("json not supported")
                     //               let assignments = try testCase.jsonAssignments(eppoClient);
@@ -110,7 +114,11 @@ final class eppoClientTests: XCTestCase {
                         defaultValue: Int(testCase.defaultValue.getDoubleValue())
                     );
                     let expectedAssignment = try? Int(subject.assignment.getDoubleValue())
-                    XCTAssertEqual(assignment, expectedAssignment)
+                    XCTAssertEqual(
+                        assignment,
+                        expectedAssignment,
+                        "FlagKey: \(testCase.flag), SubjectKey: \(subject.subjectKey)"
+                    )
                 case UFC_VariationType.numeric:
                     let assignment = try? eppoClient.getDoubleAssignment(
                         flagKey: testCase.flag,
@@ -119,7 +127,11 @@ final class eppoClientTests: XCTestCase {
                         defaultValue: testCase.defaultValue.getDoubleValue()
                     );
                     let expectedAssignment = try? subject.assignment.getDoubleValue()
-                    XCTAssertEqual(assignment, expectedAssignment)
+                    XCTAssertEqual(
+                        assignment,
+                        expectedAssignment,
+                        "FlagKey: \(testCase.flag), SubjectKey: \(subject.subjectKey)"
+                    )
                 case UFC_VariationType.string:
                     let assignment = try? eppoClient.getStringAssignment(
                         flagKey: testCase.flag,
@@ -128,7 +140,11 @@ final class eppoClientTests: XCTestCase {
                         defaultValue: testCase.defaultValue.getStringValue()
                     );
                     let expectedAssignment = try? subject.assignment.getStringValue()
-                    XCTAssertEqual(assignment, expectedAssignment)
+                    XCTAssertEqual(
+                        assignment,
+                        expectedAssignment,
+                        "FlagKey: \(testCase.flag), SubjectKey: \(subject.subjectKey)"
+                    )
                 }
             }
         }


### PR DESCRIPTION
## motivation

new data tests (https://github.com/Eppo-exp/sdk-test-data/pull/22) demonstrated some missing functionality in the swift sdk; specifically that we need to implicitly add `"id": subjectKey` to the subject attributes.

On the 

```
ClientTests.swift:143: error: -[eppo_flagging_tests.eppoClientTests testAssignments] : 
XCTAssertEqual failed: ("Optional("blue")") is not equal to ("Optional("purple")") - 
FlagKey: new-user-onboarding, SubjectKey: zach
```

## description

Merge `"id": subjectKey` into the subject attributes for rule evaluation. If "id" is already present, leave it alone.