### PR TITLE
Adds toEppoString representation of EppoValue; handles (FF-2345)

### DIFF
--- a/Sources/eppo/AssignmentCache.swift
+++ b/Sources/eppo/AssignmentCache.swift
@@ -27,12 +27,18 @@ public class InMemoryAssignmentCache: AssignmentCache {
             return false
         }
 
-        return get(key: cacheKey) == key.variationValue.toHashedString()
+        guard let variationValue = try? key.variationValue.toHashedString() else {
+            return false
+        }
+        return get(key: cacheKey) == variationValue
     }
 
     public func setLastLoggedAssignment(key: AssignmentCacheKey) {
         let cacheKey = getCacheKey(key: key)
-        set(key: cacheKey, value: key.variationValue.toHashedString())
+        guard let variationValue = try? key.variationValue.toHashedString() else {
+            return
+        }
+        set(key: cacheKey, value: variationValue)
     }
 
     internal func get(key: String) -> String? {

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -70,20 +70,20 @@ public class EppoClient {
         }
     }
     
-    public func getJSONStringAssignment(
-        flagKey: String,
-        subjectKey: String,
-        subjectAttributes: SubjectAttributes,
-        defaultValue: String) throws -> String
-    {
-        return try getInternalAssignment(
-            flagKey: flagKey, 
-            subjectKey: subjectKey, 
-            subjectAttributes: subjectAttributes,
-            expectedVariationType: UFC_VariationType.json
-        )?.variation?.value.getStringValue() ?? defaultValue
-    }
-    
+    // todo: add back when supporting JSON
+//    public func getJSONAssignment(
+//        flagKey: String,
+//        subjectKey: String,
+//        subjectAttributes: SubjectAttributes,
+//        defaultValue: [String: EppoValue]) throws -> [String: EppoValue]
+//    {
+//        return try getInternalAssignment(
+//            flagKey: flagKey, 
+//            subjectKey: subjectKey, 
+//            subjectAttributes: subjectAttributes
+//        )?.variation?.value?.objectValue() ?? defaultValue
+//    }
+//    
     
     public func getIntegerAssignment(
         flagKey: String,
@@ -105,7 +105,7 @@ public class EppoClient {
         }
     }
     
-    public func getNumericAssignment(
+    public func getDoubleAssignment(
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -196,7 +196,13 @@ public class FlagEvaluator {
             // Handle the nil case, perhaps throw an error or return a default value
             return false
         }
-        
+
+        // Safely unwrap attributeValue for further use
+        guard let value = attributeValue else {
+            // Handle the nil case, perhaps throw an error or return a default value
+            return false
+        }
+
         do {
             switch condition.operator {
             case .greaterThanEqual, .greaterThan, .lessThanEqual, .lessThan:
@@ -234,7 +240,7 @@ public class FlagEvaluator {
                             throw Errors.UnexpectedValue
                         }
                     }
-                } catch {
+                } catch let e {
                     // If stringValue() or doubleValue() throws, or Semver creation fails
                     return false
                 }

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -241,16 +241,21 @@ public class FlagEvaluator {
             case .matches:
                 return try Compare.matchesRegex(
                     value.getStringValue(),
-                    condition.value.getStringValue()
+                    condition.value.toEppoString()
+                )
+            case .notMatches:
+                return try !Compare.matchesRegex(
+                    value.getStringValue(),
+                    condition.value.toEppoString()
                 )
             case .oneOf:
                 return try Compare.isOneOf(
-                    value.getStringValue(),
+                    value.toEppoString(),
                     condition.value.getStringArrayValue()
                 )
             case .notOneOf:
                 return try !Compare.isOneOf(
-                    value.getStringValue(),
+                    value.toEppoString(),
                     condition.value.getStringArrayValue()
                 )
             default:

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -240,7 +240,7 @@ public class FlagEvaluator {
                             throw Errors.UnexpectedValue
                         }
                     }
-                } catch let e {
+                } catch {
                     // If stringValue() or doubleValue() throws, or Semver creation fails
                     return false
                 }

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -239,13 +239,13 @@ public class FlagEvaluator {
                     return false
                 }
             case .matches:
-                return try Compare.matchesRegex(
-                    value.getStringValue(),
+                return Compare.matchesRegex(
+                    value.toEppoString(),
                     condition.value.toEppoString()
                 )
             case .notMatches:
-                return try !Compare.matchesRegex(
-                    value.getStringValue(),
+                return !Compare.matchesRegex(
+                    value.toEppoString(),
                     condition.value.toEppoString()
                 )
             case .oneOf:

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -240,13 +240,13 @@ public class FlagEvaluator {
                 }
             case .matches:
                 return Compare.matchesRegex(
-                    value.toEppoString(),
-                    condition.value.toEppoString()
+                    try value.toEppoString(),
+                    try condition.value.toEppoString()
                 )
             case .notMatches:
                 return !Compare.matchesRegex(
-                    value.toEppoString(),
-                    condition.value.toEppoString()
+                    try value.toEppoString(),
+                    try condition.value.toEppoString()
                 )
             case .oneOf:
                 return try Compare.isOneOf(

--- a/Sources/eppo/RuleEvaluator.swift
+++ b/Sources/eppo/RuleEvaluator.swift
@@ -197,12 +197,6 @@ public class FlagEvaluator {
             return false
         }
 
-        // Safely unwrap attributeValue for further use
-        guard let value = attributeValue else {
-            // Handle the nil case, perhaps throw an error or return a default value
-            return false
-        }
-
         do {
             switch condition.operator {
             case .greaterThanEqual, .greaterThan, .lessThanEqual, .lessThan:

--- a/Sources/eppo/UniversalFlagConfig.swift
+++ b/Sources/eppo/UniversalFlagConfig.swift
@@ -87,6 +87,7 @@ enum UFC_RuleConditionOperator: String, Decodable {
   case greaterThan = "GT"
   case greaterThanEqual = "GTE"
   case matches = "MATCHES"
+  case notMatches = "NOT_MATCHES"
   case oneOf = "ONE_OF"
   case notOneOf = "NOT_ONE_OF"
   case isNull = "IS_NULL"

--- a/Sources/eppo/dto/EppoValue.swift
+++ b/Sources/eppo/dto/EppoValue.swift
@@ -15,7 +15,6 @@ public class EppoValue : Decodable, Equatable {
     private var doubleValue: Double?
     private var stringValue: String?
     private var stringArrayValue: [String]?
-    private var objectValue: [String: JSONValue]?
 
     enum Errors : Error {
         case valueNotSet;
@@ -87,7 +86,6 @@ public class EppoValue : Decodable, Equatable {
             self.doubleValue = nil
             self.stringValue = nil
             self.stringArrayValue = nil
-            self.objectValue = nil
         }
     }
 
@@ -190,34 +188,5 @@ public class EppoValue : Decodable, Equatable {
         let sha256Data = SHA256.hash(data: str.data(using: .utf8) ?? Data())
         return sha256Data.map { String(format: "%02x", $0) }.joined()
        
-    }
-}
-
-enum JSONValue: Decodable {
-    case string(String)
-    case int(Int)
-    case double(Double)
-    case bool(Bool)
-    case object([String: JSONValue])
-    case array([JSONValue])
-    case null
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else if let value = try? container.decode(Int.self) {
-            self = .int(value)
-        } else if let value = try? container.decode(Double.self) {
-            self = .double(value)
-        } else if let value = try? container.decode(Bool.self) {
-            self = .bool(value)
-        } else if let value = try? container.decode([JSONValue].self) {
-            self = .array(value)
-        } else if let value = try? container.decode([String: JSONValue].self) {
-            self = .object(value)
-        } else {
-            self = .null
-        }
     }
 }

--- a/Sources/eppo/dto/EppoValue.swift
+++ b/Sources/eppo/dto/EppoValue.swift
@@ -152,21 +152,52 @@ public class EppoValue : Decodable, Equatable {
         return value;
     }
 
-    public func toHashedString() -> String {
-        // todo: this is a bit of a hack. we should probably just use a switch
-        // to handle the different types.
-        var str = ""
-        if let value = self.stringValue {
-            str = value
-        } else if let array = self.stringArrayValue {
-            str = array.joined(separator: ", ")
+    public func toEppoString() -> String {
+        switch self.type {
+        case .Boolean:
+            return try! self.getBoolValue() ? "true" : "false"
+        case .Numeric:
+            if let doubleVal = try? self.getDoubleValue() {
+                if floor(doubleVal) == doubleVal {
+                    // If the double value is an integer, return as integer string
+                    return String(format: "%.0f", doubleVal)
+                } else {
+                    // Otherwise, return the double as is
+                    return String(doubleVal)
+                }
+            } else {
+                // todo: should this throw?
+                return "null"
+            }
+        case .String:
+            // todo: should this throw?
+            // it should not since we checked the type is a string above
+            // but to be true to the type system we should throw here
+            if let value = try? self.getStringValue() {
+                return value
+            } else {
+                // todo: should this throw?
+                return "null"
+            }
+        case .ArrayOfStrings:
+            if let value = try? self.getStringArrayValue() {
+                return value.joined(separator: " ,")
+            } else {
+                // todo: should this throw?
+                return "null"
+            }
+        case .Null:
+            return "null"
         }
+    }
 
+    public func toHashedString() -> String {
+        let str = self.toEppoString()
         // generate a sha256 hash of the string. this is a 32-byte signature which
         // will likely save space when using json values but will almost certainly be
         // longer than typical string variation values such as "control" or "variant".
         let sha256Data = SHA256.hash(data: str.data(using: .utf8) ?? Data())
         return sha256Data.map { String(format: "%02x", $0) }.joined()
+       
     }
 }
-

--- a/Tests/eppo/EppoValueTests.swift
+++ b/Tests/eppo/EppoValueTests.swift
@@ -70,19 +70,22 @@ class EppoValueTests: XCTestCase {
 
     func testToString() {
         // boolean
-        XCTAssertEqual(EppoValue(value: true).toEppoString(), "true")
-        XCTAssertEqual(EppoValue(value: false).toEppoString(), "false")
+        XCTAssertEqual(try EppoValue(value: true).toEppoString(), "true")
+        XCTAssertEqual(try EppoValue(value: false).toEppoString(), "false")
 
         // float
-        XCTAssertEqual(EppoValue(value: 10.5).toEppoString(), "10.5")
-        XCTAssertEqual(EppoValue(value: 10.0).toEppoString(), "10")
-        XCTAssertEqual(EppoValue(value: 123456789.0).toEppoString(), "123456789")
+        XCTAssertEqual(try EppoValue(value: 10.5).toEppoString(), "10.5")
+        XCTAssertEqual(try EppoValue(value: 10.0).toEppoString(), "10")
+        XCTAssertEqual(try EppoValue(value: 123456789.0).toEppoString(), "123456789")
 
         // int
-        XCTAssertEqual(EppoValue(value: 10).toEppoString(), "10")
+        XCTAssertEqual(try EppoValue(value: 10).toEppoString(), "10")
 
         // string
-        XCTAssertEqual(EppoValue(value: "test").toEppoString(), "test")
+        XCTAssertEqual(try EppoValue(value: "test").toEppoString(), "test")
+
+        // array of strings
+        XCTAssertEqual(try EppoValue(array: ["one", "two", "three"]).toEppoString(), "one, two, three")
     }
     
     private func jsonData(from jsonString: String) throws -> Data {

--- a/Tests/eppo/EppoValueTests.swift
+++ b/Tests/eppo/EppoValueTests.swift
@@ -68,6 +68,23 @@ class EppoValueTests: XCTestCase {
         XCTAssertFalse(arrayValue1 == arrayValueDifferent, "Arrays with different elements or counts should not be equal")
     }
 
+    func testToString() {
+        // boolean
+        XCTAssertEqual(EppoValue(value: true).toEppoString(), "true")
+        XCTAssertEqual(EppoValue(value: false).toEppoString(), "false")
+
+        // float
+        XCTAssertEqual(EppoValue(value: 10.5).toEppoString(), "10.5")
+        XCTAssertEqual(EppoValue(value: 10.0).toEppoString(), "10")
+        XCTAssertEqual(EppoValue(value: 123456789.0).toEppoString(), "123456789")
+
+        // int
+        XCTAssertEqual(EppoValue(value: 10).toEppoString(), "10")
+
+        // string
+        XCTAssertEqual(EppoValue(value: "test").toEppoString(), "test")
+    }
+    
     private func jsonData(from jsonString: String) throws -> Data {
         guard let jsonData = jsonString.data(using: .utf8) else {
             throw NSError(domain: "JSONError", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON string"])


### PR DESCRIPTION
New test was introduced in: https://github.com/Eppo-exp/sdk-test-data/pull/25

To perform comparison between different types we need a consistent representation across SDKs.

## description

We decided on a common protocol for comparing stringified numbers, integers and decimals. This PR implements that behavior in `toEppoString`

## questions for reviews

some TODOs in-line - given the interface of swift I need to handle `throw` or allow the exception to re-bubble up.