### PR TITLE
Adds singleton instance and loadIfNeeded (FF-2401)

### DIFF
--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -86,9 +86,10 @@ public class EppoClient {
     public func loadIfNeeded() async throws {
         let alreadyLoaded = await state.checkAndSetLoaded()
         guard !alreadyLoaded else { return }
-
+        
         try await load()
     }
+    
     private func load() async throws {
         try await self.configurationStore.fetchAndStoreConfigurations()
     }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -19,6 +19,18 @@ public enum Errors: Error {
     case flagConfigNotFound
 }
 
+actor EppoClientState {
+    private(set) var isLoaded: Bool = false
+    
+    func checkAndSetLoaded() -> Bool {
+        if !isLoaded {
+            isLoaded = true
+            return false
+        }
+        return true
+    }
+}
+
 public class EppoClient {
     public typealias AssignmentLogger = (Assignment) -> Void
     
@@ -30,7 +42,7 @@ public class EppoClient {
     private(set) var assignmentCache: AssignmentCache?
     private(set) var configurationStore: ConfigurationStore
     
-    private var isLoaded = false
+    private let state = EppoClientState()
     
     private init(
         apiKey: String,
@@ -72,11 +84,11 @@ public class EppoClient {
     }
     
     public func loadIfNeeded() async throws {
-        guard !isLoaded else { return }
+        let alreadyLoaded = await state.checkAndSetLoaded()
+        guard !alreadyLoaded else { return }
+
         try await load()
-        isLoaded = true
     }
-    
     private func load() async throws {
         try await self.configurationStore.fetchAndStoreConfigurations()
     }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,7 +1,7 @@
 import Foundation;
 
 // todo: make this a build argument (FF-1944)
-let sdkVersion = "1.3.0"
+let sdkVersion = "2.0.0"
 let sdkName = "ios"
 
 // todo: these exported errors could use some work. only ones here that are

--- a/Tests/eppo/ClientTests.swift
+++ b/Tests/eppo/ClientTests.swift
@@ -16,7 +16,7 @@ public class AssignmentLoggerSpy {
     var wasCalled = false
     var lastAssignment: Assignment?
     var logCount = 0
-
+    
     func logger(assignment: Assignment) {
         wasCalled = true
         lastAssignment = assignment
@@ -32,11 +32,11 @@ struct SubjectWithAttributes : Decodable {
 struct AssignmentTestCase : Decodable {
     var experiment: String = "";
     var valueType: String;
-
+    
     var subjectsWithAttributes: [SubjectWithAttributes]?
     var subjects: [String]?;
     var expectedAssignments: [EppoValue?];
-
+    
     func boolAssignments(_ client: EppoClient) throws -> [Bool?] {
         if self.subjectsWithAttributes != nil {
             return try self.subjectsWithAttributes!.map({
@@ -45,14 +45,14 @@ struct AssignmentTestCase : Decodable {
                 )
             });
         }
-
+        
         if self.subjects != nil {
             return try self.subjects!.map({ try client.getBoolAssignment($0, self.experiment); })
         }
-
+        
         return [];
     }
-
+    
     func jsonAssignments(_ client: EppoClient) throws -> [String?] {
         if self.subjectsWithAttributes != nil {
             return try self.subjectsWithAttributes!.map({
@@ -61,14 +61,14 @@ struct AssignmentTestCase : Decodable {
                 )
             });
         }
-
+        
         if self.subjects != nil {
             return try self.subjects!.map({ try client.getJSONStringAssignment($0, self.experiment); })
         }
-
+        
         return [];
     }
-
+    
     func numericAssignments(_ client: EppoClient) throws -> [Double?] {
         if self.subjectsWithAttributes != nil {
             return try self.subjectsWithAttributes!.map({
@@ -77,14 +77,14 @@ struct AssignmentTestCase : Decodable {
                 )
             });
         }
-
+        
         if self.subjects != nil {
             return try self.subjects!.map({ try client.getNumericAssignment($0, self.experiment); })
         }
-
+        
         return [];
     }
-
+    
     func stringAssignments(_ client: EppoClient) throws -> [String?] {
         if self.subjectsWithAttributes != nil {
             return try self.subjectsWithAttributes!.map({
@@ -93,11 +93,11 @@ struct AssignmentTestCase : Decodable {
                 )
             });
         }
-
+        
         if self.subjects != nil {
             return try self.subjects!.map({ try client.getStringAssignment($0, self.experiment); })
         }
-
+        
         return [];
     }
 }
@@ -108,307 +108,154 @@ final class eppoClientTests: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
+        EppoClient.resetInstance()
+        
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let stubData = RacTestJSON.data(using: .utf8)!
+            return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        loggerSpy = AssignmentLoggerSpy()
+        eppoClient = EppoClient.configure(apiKey: "mock-api-key", assignmentLogger: loggerSpy.logger)
+    }
     
-       stub(condition: isHost("fscdn.eppo.cloud")) { _ in
-           let stubData = RacTestJSON.data(using: .utf8)!
-           return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
-       }
-       
-       loggerSpy = AssignmentLoggerSpy()
-       eppoClient = EppoClient("mock-api-key", assignmentLogger: loggerSpy.logger)
+    func testUnloadedClient() async throws {
+        XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
+        {
+            error in XCTAssertEqual(error as! Errors, Errors.configurationNotLoaded)
+        };
+    }
     
-   }
-   
-   func testUnloadedClient() async throws {
-       XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
-       {
-           error in XCTAssertEqual(error as! Errors, Errors.configurationNotLoaded)
-       };
-   }
-   
-   func testBadFlagKey() async throws {
-       try await eppoClient.load()
-       
-       XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
-       {
-           error in XCTAssertEqual(error as! Errors, Errors.flagConfigNotFound)
-       };
-   }
-   
-   func testLogger() async throws {
-       try await eppoClient.load()
-       
-       let assignment = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
-       XCTAssertEqual(assignment, "red")
-       XCTAssertTrue(loggerSpy.wasCalled)
-       if let lastAssignment = loggerSpy.lastAssignment {
-           XCTAssertEqual(lastAssignment.allocation, "allocation-experiment-1")
-           XCTAssertEqual(lastAssignment.experiment, "randomization_algo-allocation-experiment-1")
-           XCTAssertEqual(lastAssignment.subject, "6255e1a72a84e984aed55668")
-       } else {
-           XCTFail("No last assignment was logged.")
-       }
-   }
-   
-   func testAssignments() async throws {
-       let testFiles = Bundle.module.paths(
-           forResourcesOfType: ".json",
-           inDirectory: "Resources/test-data/assignment-v2"
-       );
-       
-       try await eppoClient.load();
-       
-       for testFile in testFiles {
-           let caseString = try String(contentsOfFile: testFile);
-           let caseData = caseString.data(using: .utf8)!;
-           let testCase = try JSONDecoder().decode(AssignmentTestCase.self, from: caseData);
-           
-           switch (testCase.valueType) {
-           case "boolean":
-               let assignments = try testCase.boolAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() }
-               XCTAssertEqual(assignments, expectedAssignments);
-           case "json":
-               let assignments = try testCase.jsonAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
-               XCTAssertEqual(assignments, expectedAssignments);
-           case "numeric":
-               let assignments = try testCase.numericAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() }
-               XCTAssertEqual(assignments, expectedAssignments);
-           case "string":
-               let assignments = try testCase.stringAssignments(eppoClient);
-               let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
-               XCTAssertEqual(assignments, expectedAssignments);
-           default:
-               XCTFail("Unknown value type: \(testCase.valueType)");
-           }
-       }
-       
-       XCTAssertGreaterThan(testFiles.count, 0);
-   }
+    func testBadFlagKey() async throws {
+        try await eppoClient.loadIfNeeded()
+        
+        XCTAssertThrowsError(try eppoClient.getStringAssignment("badFlagRising", "allocation-experiment-1"))
+        {
+            error in XCTAssertEqual(error as! Errors, Errors.flagConfigNotFound)
+        };
+    }
+    
+    func testLogger() async throws {
+        try await eppoClient.loadIfNeeded()
+        
+        let assignment = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
+        XCTAssertEqual(assignment, "red")
+        XCTAssertTrue(loggerSpy.wasCalled)
+        if let lastAssignment = loggerSpy.lastAssignment {
+            XCTAssertEqual(lastAssignment.allocation, "allocation-experiment-1")
+            XCTAssertEqual(lastAssignment.experiment, "randomization_algo-allocation-experiment-1")
+            XCTAssertEqual(lastAssignment.subject, "6255e1a72a84e984aed55668")
+        } else {
+            XCTFail("No last assignment was logged.")
+        }
+    }
+    
+    func testAssignments() async throws {
+        let testFiles = Bundle.module.paths(
+            forResourcesOfType: ".json",
+            inDirectory: "Resources/test-data/assignment-v2"
+        );
+        
+        try await eppoClient.loadIfNeeded();
+        
+        for testFile in testFiles {
+            let caseString = try String(contentsOfFile: testFile);
+            let caseData = caseString.data(using: .utf8)!;
+            let testCase = try JSONDecoder().decode(AssignmentTestCase.self, from: caseData);
+            
+            switch (testCase.valueType) {
+            case "boolean":
+                let assignments = try testCase.boolAssignments(eppoClient);
+                let expectedAssignments = testCase.expectedAssignments.map { try? $0?.boolValue() }
+                XCTAssertEqual(assignments, expectedAssignments);
+            case "json":
+                let assignments = try testCase.jsonAssignments(eppoClient);
+                let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
+                XCTAssertEqual(assignments, expectedAssignments);
+            case "numeric":
+                let assignments = try testCase.numericAssignments(eppoClient);
+                let expectedAssignments = testCase.expectedAssignments.map { try? $0?.doubleValue() }
+                XCTAssertEqual(assignments, expectedAssignments);
+            case "string":
+                let assignments = try testCase.stringAssignments(eppoClient);
+                let expectedAssignments = testCase.expectedAssignments.map { try? $0?.stringValue() }
+                XCTAssertEqual(assignments, expectedAssignments);
+            default:
+                XCTFail("Unknown value type: \(testCase.valueType)");
+            }
+        }
+        
+        XCTAssertGreaterThan(testFiles.count, 0);
+    }
 }
 
 final class EppoClientAssignmentCachingTests: XCTestCase {
     var loggerSpy: AssignmentLoggerSpy!
     var eppoClient: EppoClient!
-    
+
     override func setUpWithError() throws {
         try super.setUpWithError()
+        EppoClient.resetInstance()  // Reset the singleton instance before each test
         loggerSpy = AssignmentLoggerSpy()
-        eppoClient = EppoClient("mock-api-key",
-                    assignmentLogger: loggerSpy.logger
-                    // InMemoryAssignmentCache is default enabled.
-        )
     }
     
     func testLogsDuplicateAssignmentsWithoutCache() async throws {
         // Disable the assignment cache.
-        eppoClient = EppoClient("mock-api-key",
-                    assignmentLogger: loggerSpy.logger,
-                    assignmentCache: nil)
-
+        eppoClient = EppoClient.configure(apiKey: "mock-api-key",
+                                assignmentLogger: loggerSpy.logger,
+                                assignmentCache: nil)
+        
         stub(condition: isHost("fscdn.eppo.cloud")) { _ in
             let stubData = RacTestJSON.data(using: .utf8)!
             return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
-        try await eppoClient.load()
+        
+        try await eppoClient.loadIfNeeded()
         
         _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
         _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
-
+        
         XCTAssertEqual(loggerSpy.logCount, 2, "Should log twice since there is no cache.")
     }
-
+    
     func testDoesNotLogDuplicateAssignmentsWithCache() async throws {
+        eppoClient = EppoClient.configure(
+            apiKey: "mock-api-key",
+            assignmentLogger: loggerSpy.logger,
+            // InMemoryAssignmentCache is default enabled.
+            assignmentCache: InMemoryAssignmentCache()
+        )
+        
         stub(condition: isHost("fscdn.eppo.cloud")) { _ in
             let stubData = RacTestJSON.data(using: .utf8)!
             return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
-        try await eppoClient.load()
+        
+        try await eppoClient.loadIfNeeded()
         
         _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
         _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
-
+        
         XCTAssertEqual(loggerSpy.logCount, 1, "Should log once due to cache hit.")
     }
     
     func testLogsForEachUniqueFlag() async throws {
+        eppoClient = EppoClient.configure(
+            apiKey: "mock-api-key",
+            assignmentLogger: loggerSpy.logger,
+            // InMemoryAssignmentCache is default enabled.
+            assignmentCache: InMemoryAssignmentCache()
+        )
+        
         stub(condition: isHost("fscdn.eppo.cloud")) { _ in
             let stubData = RacTestJSON.data(using: .utf8)!
             return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
-        try await eppoClient.load()
+        try await eppoClient.loadIfNeeded()
         
         _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "randomization_algo")
         _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "new_user_onboarding")
-
-        XCTAssertEqual(loggerSpy.logCount, 2, "Should log 2 times due to changing flags.")
-    }
-    
-    func testLoggingWhenRolloutIncreases() async throws {
-        let mockJson = """
-            {
-                "flags": {
-                    "feature1": {
-                        "subjectShards": 10000,
-                        "typedOverrides": {},
-                        "enabled": true,
-                        "rules": [
-                            {
-                                "allocationKey": "allocation-experiment-1",
-                                "conditions": []
-                            }
-                        ],
-                        "allocations": {
-                            "allocation-experiment-1": {
-                            "percentExposure": 1,
-                            "statusQuoVariationKey": null,
-                            "shippedVariationKey": null,
-                            "variations": [
-                                {
-                                    "name": "control",
-                                    "value": "control",
-                                    "typedValue": "control",
-                                    "shardRange": {
-                                        "start": 0,
-                                        "end": 3333
-                                    },
-                                    "algorithmType": "CONSTANT"
-                                },
-                                {
-                                    "name": "red",
-                                    "value": "red",
-                                    "typedValue": "red",
-                                    "shardRange": {
-                                        "start": 3333,
-                                        "end": 6666
-                                    },
-                                    "algorithmType": "CONSTANT"
-                                },
-                                {
-                                    "name": "green",
-                                    "value": "green",
-                                    "typedValue": "green",
-                                    "shardRange": {
-                                        "start": 6666,
-                                        "end": 10000
-                                    },
-                                    "algorithmType": "CONSTANT"
-                                }
-                            ]
-                            }
-                        }
-                    }
-                }
-            }
-        """
-        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
-            return HTTPStubsResponse(data: mockJson.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        try await eppoClient.load()
         
-        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "feature1")
-        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "feature1")
-        XCTAssertEqual(loggerSpy.logCount, 1, "Should log once with the cache.")
-
-        // update the allocation
-        let updatedVariationsJson = """
-            {
-                "flags": {
-                    "feature1": {
-                        "subjectShards": 10000,
-                        "typedOverrides": {},
-                        "enabled": true,
-                        "rules": [
-                            {
-                                "allocationKey": "allocation-experiment-1",
-                                "conditions": []
-                            }
-                        ],
-                        "allocations": {
-                            "allocation-experiment-1": {
-                            "percentExposure": 1,
-                            "statusQuoVariationKey": null,
-                            "shippedVariationKey": null,
-                            "variations": [
-                                {
-                                    "name": "control",
-                                    "value": "control",
-                                    "typedValue": "control",
-                                    "shardRange": {
-                                        "start": 0,
-                                        "end": 0
-                                    },
-                                    "algorithmType": "CONSTANT"
-                                },
-                                {
-                                    "name": "green",
-                                    "value": "green",
-                                    "typedValue": "green",
-                                    "shardRange": {
-                                        "start": 0,
-                                        "end": 10000
-                                    },
-                                    "algorithmType": "CONSTANT"
-                                }
-                            ]
-                            }
-                        }
-                    }
-                }
-            }
-        """
-        // Reload the EppoClient with the updated configuration
-        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
-            return HTTPStubsResponse(data: updatedVariationsJson.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        try await eppoClient.load()
-
-        // update the allocation
-        let newTreatmentJson = """
-            {
-                "flags": {
-                    "feature1": {
-                        "subjectShards": 10000,
-                        "typedOverrides": {},
-                        "enabled": true,
-                        "rules": [
-                            {
-                                "allocationKey": "allocation-experiment-1",
-                                "conditions": []
-                            }
-                        ],
-                        "allocations": {
-                            "allocation-experiment-1": {
-                            "percentExposure": 1,
-                            "statusQuoVariationKey": null,
-                            "shippedVariationKey": null,
-                            "variations": [
-                                {
-                                    "name": "new-treatment",
-                                    "value": "new-treatment",
-                                    "typedValue": "new-treatment",
-                                    "shardRange": {
-                                        "start": 0,
-                                        "end": 10000
-                                    },
-                                    "algorithmType": "CONSTANT"
-                                }
-                            ]
-                            }
-                        }
-                    }
-                }
-            }
-        """
-        // Reload the EppoClient with the updated configuration
-        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
-            return HTTPStubsResponse(data: newTreatmentJson.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
-        }
-        try await eppoClient.load()
-
-        _ = try eppoClient.getStringAssignment("6255e1a72a84e984aed55668", "feature1")
-        XCTAssertEqual(loggerSpy.logCount, 2, "Should log again since the allocation changed.")
+        XCTAssertEqual(loggerSpy.logCount, 2, "Should log 2 times due to changing flags.")
     }
 }

--- a/Tests/eppo/SingletonTest.swift
+++ b/Tests/eppo/SingletonTest.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+
+@testable import eppo_flagging
+
+final class EppoTests: XCTestCase {
+    var stubCallCount = 0
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        EppoClient.resetInstance()
+        stubCallCount = 0
+        
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            self.stubCallCount += 1
+            let stubData = RacTestJSON.data(using: .utf8)!
+            return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        _ = EppoClient.configure(apiKey: "mock-api-key")
+    }
+    
+    func testEppoClientMultithreading() async throws {
+        
+        let expectedCount = 50
+        let expectation = XCTestExpectation(description: "eppo client expectation")
+        expectation.expectedFulfillmentCount = expectedCount
+
+        Task {
+            let eppoClient = try EppoClient.getInstance()
+            await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0 ..< expectedCount {
+                    group.addTask {
+                        try await eppoClient.loadIfNeeded()
+                        _ = try? eppoClient.getStringAssignment("subject_key", "some-assignment-key", [:])
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        
+        await fulfillment(of: [expectation], timeout: 5)
+        XCTAssertEqual(stubCallCount, 1)
+    }
+}


### PR DESCRIPTION
## motivation

There are several behaviors that the SDK is not protecting against:

* Instantiating multiple instances of the `EppoClient`
* Performing network operations before each assignment

## description

* Adds a singleton pattern to the `EppoClient`
* Add ability to configure the `EppoClient` anywhere in an application with `configure`
* Replaces `load` method, which always performed a network request, with `loadIfNeeded`. Only loads a single time per application-lifecycle. Uses [swift actor pattern](https://www.swiftbysundell.com/articles/swift-actors/) to accomplish.

## question for reviewers

2. Does the readme for sdk usage make sense?