### PR TITLE
Fix: [assignment cache is sensitive to changes in allocation or variation key] (FF-2435)

### DIFF
--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -155,7 +155,8 @@ public class EppoClient {
                 subjectKey: subjectKey,
                 flagKey: flagKey,
                 allocationKey: rule.allocationKey,
-                variationValue: assignedVariation.typedValue
+                // TODO: Migrate to using the variationKey after the UFC is available.
+                variationKey: assignedVariation.typedValue.toHashedString()
             )
             
             // Check if the assignment has already been logged, if the cache is defined

--- a/Tests/eppo/AssignmentCacheTests.swift
+++ b/Tests/eppo/AssignmentCacheTests.swift
@@ -15,33 +15,66 @@ final class AssignmentCacheTests: XCTestCase {
         cache = nil
         super.tearDown()
     }
-    
-    func testSetAndGet() {
-        let key = "testKey"
-        let value = "testValue"
-        XCTAssertNil(cache.get(key: key), "Cache should return nil for a key that has not been set.")
-        cache.set(key: key, value: value)
-        XCTAssertEqual(cache.get(key: key), value, "Cache should return the value that was set for a key.")
-    }
-    
-    func testHas() {
-        let key = "testKey"
-        XCTAssertFalse(cache.has(key: key), "Cache should return false for a key that has not been set.")
-        cache.set(key: key, value: "testValue")
-        XCTAssertTrue(cache.has(key: key), "Cache should return true for a key that has been set.")
-    }
-    
-    func testHasLoggedAssignment() {
-        let assignmentKey = AssignmentCacheKey(
+
+    func testOscillatingAllocation() {
+        let key1 = AssignmentCacheKey(
             subjectKey: "Math", 
             flagKey: "TestFlag",
-            allocationKey: "A1",
-            variationValue: EppoValue(value: "VariationA", type: EppoValueType.String)
+            allocationKey: "A1", // initial
+            variationKey: EppoValue(value: "VariationA", type: EppoValueType.String).toHashedString()
         )
-        
-        XCTAssertFalse(cache.hasLoggedAssignment(key: assignmentKey), "Cache should return false for an assignment that has not been logged.")
-        
-        cache.setLastLoggedAssignment(key: assignmentKey)
-        XCTAssertTrue(cache.hasLoggedAssignment(key: assignmentKey), "Cache should return true for an assignment that has been logged.")
+        let key2 = AssignmentCacheKey(
+            subjectKey: "Math", 
+            flagKey: "TestFlag",
+            allocationKey: "A2", // changes
+            variationKey: EppoValue(value: "VariationA", type: EppoValueType.String).toHashedString()
+        )
+
+        cache.setLastLoggedAssignment(key: key1)
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key1))
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key2))
+
+        cache.setLastLoggedAssignment(key: key2)
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key1))
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key2))
+
+        cache.setLastLoggedAssignment(key: key1)
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key1))
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key2))
+
+        cache.setLastLoggedAssignment(key: key2)
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key1))
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key2))
+    }
+    
+    func testOscillatingVariations() {
+        let key1 = AssignmentCacheKey(
+            subjectKey: "Math",
+            flagKey: "TestFlag",
+            allocationKey: "A1",
+            variationKey: EppoValue(value: "VariationA", type: EppoValueType.String).toHashedString()  // initial
+        )
+        let key2 = AssignmentCacheKey(
+            subjectKey: "Math",
+            flagKey: "TestFlag",
+            allocationKey: "A1",
+            variationKey: EppoValue(value: "VariationB", type: EppoValueType.String).toHashedString()  // changes
+        )
+
+        cache.setLastLoggedAssignment(key: key1)
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key1))
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key2))
+
+        cache.setLastLoggedAssignment(key: key2)
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key1))
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key2))
+
+        cache.setLastLoggedAssignment(key: key1)
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key1))
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key2))
+
+        cache.setLastLoggedAssignment(key: key2)
+        XCTAssertFalse(cache.hasLoggedAssignment(key: key1))
+        XCTAssertTrue(cache.hasLoggedAssignment(key: key2))
     }
 }


### PR DESCRIPTION
## Observed behavior

The assignment cache is not logging changes in allocations.

## Desired behavior

The assignment cache should log the assignment if either the allocation or variation key change.

## Details

A caveat: the variation key is not available in the RAC. This change is being developed against the `1.x` branch in order to fix an undesirable bug. A modification will be developed against the `3.x` UFC branch. As such as are using the stringified variation value as a substitute.

* Converts the `Map[String, String]` to a `Map[CacheKey, CacheValue]` - this allows us to pick the two attributes from the public interface `AssignmentCacheKey` which break the cache when they change. In this change that is being expanded from just the variation value to the allocation key too. With the change away from `String`, some code can be removed by implementing the `Hashable` and `Equatable` interfaces in the `CacheKey` and `CacheValue`, respectively.
* Keeping the interface to the class the same.

## Deployment

* Tag `1.2.2` will be created from this branch and a release created for it.
* An additional branch will be made against (https://github.com/Eppo-exp/eppo-ios-sdk/pull/21) to use the actual variation key.