### PR TITLE
bug: [add more detailed debugging messages to json decoder] (FF-2580)

### DIFF
--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -1,6 +1,6 @@
 import Foundation;
 
-let UFC_CONFIG_URL = "api/flag-config/v1/config"
+let UFC_CONFIG_URL = "/api/flag-config/v1/config"
 
 class ConfigurationRequester {
     private let httpClient: EppoHttpClient;

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -1,6 +1,6 @@
 import Foundation;
 
-let RAC_CONFIG_URL = "/api/randomized_assignment/v3/config"
+let UFC_CONFIG_URL = "api/flag-config/v1/config"
 
 class ConfigurationRequester {
     private let httpClient: EppoHttpClient;
@@ -10,7 +10,7 @@ class ConfigurationRequester {
     }
 
     public func fetchConfigurations() async throws -> UniversalFlagConfig {
-        let (urlData, _) = try await httpClient.get(RAC_CONFIG_URL);
+        let (urlData, _) = try await httpClient.get(UFC_CONFIG_URL);
         return try UniversalFlagConfig.decodeFromJSON(from: String(data: urlData, encoding: .utf8)!);
     }
 }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -58,7 +58,7 @@ public class EppoClient {
         self.assignmentLogger = assignmentLogger
         self.assignmentCache = assignmentCache
         
-        let httpClient = NetworkEppoHttpClient(baseURL: host, sdkKey: sdkKey, sdkName: "sdkName", sdkVersion: "sdkVersion")
+        let httpClient = NetworkEppoHttpClient(baseURL: host, sdkKey: sdkKey, sdkName: "sdkName", sdkVersion: sdkVersion)
         let configurationRequester = ConfigurationRequester(httpClient: httpClient)
         self.configurationStore = ConfigurationStore(requester: configurationRequester)
     }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -2,7 +2,7 @@ import Foundation;
 
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "3.0.0"
+public let sdkVersion = "3.0.1"
 
 public enum Errors: Error {
     case notConfigured

--- a/Sources/eppo/Obfuscation.swift
+++ b/Sources/eppo/Obfuscation.swift
@@ -21,6 +21,13 @@ func getMD5Hex(_ value: String) -> String {
     return digestData.map { String(format: "%02hhx", $0) }.joined()
 }
 
+func base64Encode(_ value: String) -> String {
+    guard let data = value.data(using: .utf8) else {
+        return ""
+    }
+    return data.base64EncodedString()
+}
+
 func base64Decode(_ value: String) -> String? {
     if let decodedData = Data(base64Encoded: value) {
         return String(data: decodedData, encoding: .utf8)

--- a/Sources/eppo/UniversalFlagConfig.swift
+++ b/Sources/eppo/UniversalFlagConfig.swift
@@ -3,7 +3,6 @@ import Foundation
 public struct UniversalFlagConfig : Decodable {
     let createdAt: Date?;
     let flags: [String: UFC_Flag];
-    // todo: add bandits
     
     static func decodeFromJSON(from jsonString: String) throws -> UniversalFlagConfig {
         guard let jsonData = jsonString.data(using: .utf8) else {
@@ -17,7 +16,6 @@ public struct UniversalFlagConfig : Decodable {
             let container = try decoder.singleValueContainer()
             let dateStr = try container.decode(String.self)
             guard let date = parseUtcISODateElement(dateStr) else {
-                print(dateStr)
                 throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format for: <\(dateStr)>")
             }
             return date
@@ -28,13 +26,13 @@ public struct UniversalFlagConfig : Decodable {
         } catch let error as DecodingError {
             switch error {
             case .typeMismatch(_, let context):
-                throw UniversalFlagConfigError.parsingError("Type mismatch: \(context.debugDescription)")
+                throw UniversalFlagConfigError.parsingError("Type mismatch: \(context.debugDescription) - \(String(describing: context.underlyingError))")
             case .valueNotFound(_, let context):
-                throw UniversalFlagConfigError.parsingError("Value not found: \(context.debugDescription)")
+                throw UniversalFlagConfigError.parsingError("Value not found: \(context.debugDescription) - \(String(describing: context.underlyingError))")
             case .keyNotFound(let key, let context):
-                throw UniversalFlagConfigError.parsingError("Key not found: \(key.stringValue) - \(context.debugDescription)")
+                throw UniversalFlagConfigError.parsingError("Key not found: \(key.stringValue) - \(context.debugDescription) - \(String(describing: context.underlyingError))")
             case .dataCorrupted(let context):
-                throw UniversalFlagConfigError.parsingError("Data corrupted: \(context.debugDescription)")
+                throw UniversalFlagConfigError.parsingError("Data corrupted: \(context.debugDescription) - \(String(describing: context.underlyingError))")
             default:
                 throw UniversalFlagConfigError.parsingError("JSON parsing error: \(error.localizedDescription)")
             }

--- a/Sources/eppo/UniversalFlagConfig.swift
+++ b/Sources/eppo/UniversalFlagConfig.swift
@@ -26,13 +26,13 @@ public struct UniversalFlagConfig : Decodable {
         } catch let error as DecodingError {
             switch error {
             case .typeMismatch(_, let context):
-                throw UniversalFlagConfigError.parsingError("Type mismatch: \(context.debugDescription) - \(String(describing: context.underlyingError))")
+                throw UniversalFlagConfigError.parsingError("Type mismatch: \(context.debugDescription)")
             case .valueNotFound(_, let context):
-                throw UniversalFlagConfigError.parsingError("Value not found: \(context.debugDescription) - \(String(describing: context.underlyingError))")
+                throw UniversalFlagConfigError.parsingError("Value not found: \(context.debugDescription)")
             case .keyNotFound(let key, let context):
-                throw UniversalFlagConfigError.parsingError("Key not found: \(key.stringValue) - \(context.debugDescription) - \(String(describing: context.underlyingError))")
+                throw UniversalFlagConfigError.parsingError("Key not found: \(key.stringValue) - \(context.debugDescription)")
             case .dataCorrupted(let context):
-                throw UniversalFlagConfigError.parsingError("Data corrupted: \(context.debugDescription) - \(String(describing: context.underlyingError))")
+                throw UniversalFlagConfigError.parsingError("Data corrupted: \(context.debugDescription)")
             default:
                 throw UniversalFlagConfigError.parsingError("JSON parsing error: \(error.localizedDescription)")
             }

--- a/Tests/eppo/UniversalFlagConfigTests.swift
+++ b/Tests/eppo/UniversalFlagConfigTests.swift
@@ -58,20 +58,23 @@ final class UniversalFlagConfigTest: XCTestCase {
         let config = try! UniversalFlagConfig.decodeFromJSON(from: UFCTestJSON)
         
         // empty flag
-        let emptyFlag = config.flags.first(where: { $0.key == "empty_flag" })?.value
+        let emptyFlag = config.flags.first(where: { $0.key == getMD5Hex("empty_flag") })?.value
         XCTAssertTrue(emptyFlag?.enabled == true, "The 'empty_flag' flag should be enabled.")
         
         // disabled flag
-        let disabledFlag = config.flags.first(where: { $0.key == "disabled_flag" })?.value
+        let disabledFlag = config.flags.first(where: { $0.key == getMD5Hex("disabled_flag") })?.value
         XCTAssertTrue(disabledFlag?.enabled == false, "The 'disabled_flag' flag should be disabled.")
         
         // variation type
-        let variationFlag = config.flags.first(where: { $0.key == "numeric_flag" })?.value
+        let variationFlag = config.flags.first(where: { $0.key == getMD5Hex("numeric_flag") })?.value
         XCTAssertEqual(variationFlag?.enabled, true, "The 'numeric_flag' flag should be enabled.")
         XCTAssertEqual(variationFlag?.variationType, UFC_VariationType.numeric, "The 'numeric_flag' flag should have a variation type of 'NUMERIC'.")
         XCTAssertEqual(variationFlag?.variations.count, 2, "The 'numeric_flag' flag should have 2 variations.")
-        XCTAssertEqual(variationFlag?.variations["e"]?.key, "e", "The 'numeric_flag' flag should have a variation key of 'e'.")
-        XCTAssertEqual(try variationFlag?.variations["e"]?.value.getDoubleValue(), 2.7182818)
+        XCTAssertEqual(variationFlag?.variations[base64Encode("e")]?.key, base64Encode("e"), "The 'numeric_flag' flag should have a variation key of 'e'.")
+        
+        let variationValue = try! variationFlag?.variations[base64Encode("e")]?.value.getStringValue()
+        let decodedVariationValue = base64Decode(variationValue ?? "")
+        XCTAssertEqual(decodedVariationValue, "2.7182818")
 
         // total shards
         XCTAssertEqual(variationFlag?.totalShards, 10000, "The total shards should be 10000.")
@@ -89,7 +92,7 @@ final class UniversalFlagConfigTest: XCTestCase {
                 return
             }
             XCTAssertEqual(thrownError.errorCode, 101, "Error code should be 101 indicating a JSON parsing issue")
-            XCTAssertEqual(thrownError.localizedDescription, "Data corrupted: The given data was not valid JSON.")
+            XCTAssertTrue(thrownError.localizedDescription.hasPrefix("Data corrupted: The given data was not valid JSON."))
         }
     }
 }

--- a/Tests/eppo/UniversalFlagConfigTests.swift
+++ b/Tests/eppo/UniversalFlagConfigTests.swift
@@ -92,7 +92,7 @@ final class UniversalFlagConfigTest: XCTestCase {
                 return
             }
             XCTAssertEqual(thrownError.errorCode, 101, "Error code should be 101 indicating a JSON parsing issue")
-            XCTAssertTrue(thrownError.localizedDescription.hasPrefix("Data corrupted: The given data was not valid JSON."))
+            XCTAssertEqual(thrownError.localizedDescription, "Data corrupted: The given data was not valid JSON.")
         }
     }
 }

--- a/Tests/eppo/UniversalFlagConfigTests.swift
+++ b/Tests/eppo/UniversalFlagConfigTests.swift
@@ -5,11 +5,10 @@ import Foundation
 @testable import eppo_flagging
 
 final class UniversalFlagConfigTest: XCTestCase {
-    var fileURL: URL!
-    var UFCTestJSON: String!
-
-    override func setUp() {
-        super.setUp()
+    func testDecodeUFCConfig() {
+        var fileURL: URL!
+        var UFCTestJSON: String!
+        
         fileURL = Bundle.module.url(
             forResource: "Resources/test-data/ufc/flags-v1.json",
             withExtension: ""
@@ -19,9 +18,43 @@ final class UniversalFlagConfigTest: XCTestCase {
         } catch {
             XCTFail("Error loading test JSON: \(error)")
         }
-    }
+        
+        let config = try! UniversalFlagConfig.decodeFromJSON(from: UFCTestJSON)
+        
+        // empty flag
+        let emptyFlag = config.flags.first(where: { $0.key == "empty_flag" })?.value
+        XCTAssertTrue(emptyFlag?.enabled == true, "The 'empty_flag' flag should be enabled.")
+        
+        // disabled flag
+        let disabledFlag = config.flags.first(where: { $0.key == "disabled_flag" })?.value
+        XCTAssertTrue(disabledFlag?.enabled == false, "The 'disabled_flag' flag should be disabled.")
+        
+        // variation type
+        let variationFlag = config.flags.first(where: { $0.key == "numeric_flag" })?.value
+        XCTAssertEqual(variationFlag?.enabled, true, "The 'numeric_flag' flag should be enabled.")
+        XCTAssertEqual(variationFlag?.variationType, UFC_VariationType.numeric, "The 'numeric_flag' flag should have a variation type of 'NUMERIC'.")
+        XCTAssertEqual(variationFlag?.variations.count, 2, "The 'numeric_flag' flag should have 2 variations.")
+        XCTAssertEqual(variationFlag?.variations["e"]?.key, "e", "The 'numeric_flag' flag should have a variation key of 'e'.")
+        XCTAssertEqual(try variationFlag?.variations["e"]?.value.getDoubleValue(), 2.7182818)
 
-    func testDecodeUFCConfig() {
+        // total shards
+        XCTAssertEqual(variationFlag?.totalShards, 10000, "The total shards should be 10000.")
+    }
+    
+    func testDecodeObfuscatedUFCConfig() {
+        var fileURL: URL!
+        var UFCTestJSON: String!
+        
+        fileURL = Bundle.module.url(
+            forResource: "Resources/test-data/ufc/flags-v1-obfuscated.json",
+            withExtension: ""
+        )
+        do {
+            UFCTestJSON = try String(contentsOfFile: fileURL.path)
+        } catch {
+            XCTFail("Error loading test JSON: \(error)")
+        }
+        
         let config = try! UniversalFlagConfig.decodeFromJSON(from: UFCTestJSON)
         
         // empty flag


### PR DESCRIPTION
**motivation**

addressing two bugs:

* http requests going to RAC path instead of UFC
* `sdkVersion` hard-coded to string `sdkVersion` instead of the variable

**additional testing**

* decoding the obfuscated rac