### PR TITLE
feat: [add `load` function to EppoClient] (FF-2907)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ public class AssignmentObserver: ObservableObject {
 }
 ```
 
-
 Rendering the view:
 
 ```swift

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -102,8 +102,8 @@ public class EppoClient {
 
     // Loads the configuration from the remote source on-demand. Can be used to refresh as desired.
     //
-    // This function can be called from multiple threads; syncronization is provided for the
-    // configuration cache but each invocation will execute a new network request with billing impact.
+    // This function can be called from multiple threads; synchronization is provided to safely update
+    // the configuration cache but each invocation will execute a new network request with billing impact.
     public func load() async throws {
         try await self.configurationStore.fetchAndStoreConfigurations()
     }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -2,7 +2,7 @@ import Foundation;
 
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "3.0.1"
+public let sdkVersion = "3.1.0"
 
 public enum Errors: Error {
     case notConfigured
@@ -98,6 +98,14 @@ public class EppoClient {
             throw Errors.notConfigured
         }
         return instance
+    }
+
+    // Loads the configuration from the remote source on-demand. Can be used to refresh as desired.
+    //
+    // This function can be called from multiple threads; syncronization is provided for the
+    // configuration cache but each invocation will execute a new network request with billing impact.
+    public func load() async throws {
+        try await self.configurationStore.fetchAndStoreConfigurations()
     }
     
     public static func resetSharedInstance() {


### PR DESCRIPTION
## Observations

There is customer demand for ad-hoc configuration reloading. On clients with long-running sessions it is desirable to refresh the configuration periodically.

## Changes

Adds a `load` method to the public API.