### PR TITLE
quality: parameterize SDK and test-data branches

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,12 +1,44 @@
 name: Swift
 
-on: [push]
+env:
+  SDK_BRANCH_NAME: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name }}
+  TEST_DATA_BRANCH_NAME: ${{ inputs.test_data_branch || 'main' }}
+
+on:
+  push:
+
+  pull_request:
+
+  workflow_dispatch:
+
+  workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
 
 jobs:
   build:
     runs-on: macos-latest
     steps:
+      - name: Display Testing Details
+        run: |
+          echo "Running SDK Test using"
+          echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"
+          echo "SDK Branch: ios-sdk@${SDK_BRANCH_NAME}"
+
       - uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/ios-sdk
+          ref: ${{ env.SDK_BRANCH_NAME}}
+
+
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,4 +46,3 @@ jobs:
 
       - name: Run tests
         run: make test
-x

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,18 +38,11 @@ jobs:
           repository: Eppo-exp/ios-sdk
           ref: ${{ env.SDK_BRANCH_NAME}}
 
-
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-
-      - name: 'Use gcloud CLI'
-        run: 'gcloud info'
-
       - name: Build
         run: make build
 
       - name: Pull test data
-        run: make test-data
+        run: make test-data branchName=${{env.TEST_DATA_BRANCH_NAME}}
 
       - name: Run tests
         run: make test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,7 @@ env:
 
 on:
   push:
+    branches: [main]
 
   pull_request:
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,11 +31,11 @@ jobs:
         run: |
           echo "Running SDK Test using"
           echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"
-          echo "SDK Branch: ios-sdk@${SDK_BRANCH_NAME}"
+          echo "SDK Branch: eppo-ios-sdk@${SDK_BRANCH_NAME}"
 
       - uses: actions/checkout@v3
         with:
-          repository: Eppo-exp/ios-sdk
+          repository: Eppo-exp/eppo-ios-sdk
           ref: ${{ env.SDK_BRANCH_NAME}}
 
       - name: Build
@@ -46,3 +46,4 @@ jobs:
 
       - name: Run tests
         run: make test
+x

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 	swift build
 
 .PHONY: test
-test: test-data
+test:
 	swift test
 
 ## test-data

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 	swift build
 
 .PHONY: test
-test: 
+test: test-data
 	swift test
 
 ## test-data


### PR DESCRIPTION
🎟️ Fixes FF-3096 towards FF-3085

👯‍♂️ **Related PRs**

- [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/pull/59)
- [react-native-sdk](https://github.com/Eppo-exp/react-native-sdk/pull/58)
- [golang-sdk](https://github.com/Eppo-exp/golang-sdk/pull/66)
- [android-sdk](https://github.com/Eppo-exp/android-sdk/pull/93)


### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) get two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).