### PR TITLE
feat: [add support for initializing the SDK from a static json config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,42 @@ Task {
 }
 ```
 
+#### Offline initialization
+
+If you'd like to initialize Eppo's client without performing a network request, you can pass in a pre-fetched configuration JSON string.
+
+```swift
+try EppoClient.initialize(
+    configurationJson: "PRE-FETCHED-CONFIGURATION-JSON",
+    obfuscated: false
+);
+```
+
+The `obfuscated` parameter is used to inform the SDK if the flag configuration is obfuscated.
+
+The initialization method is synchronous and allows you to perform assignments immediately.
+
+**(Optional) Fetching the configuration from the remote source on-demand.**
+
+Combine both initialization methods to start your application with a local configuration and then 
+asynchronously fetch the latest flag configuration from the remote source.
+
+```swift
+try EppoClient.initialize(
+    configurationJson: "PRE-FETCHED-CONFIGURATION-JSON",
+    obfuscated: false,
+);
+
+...
+
+Task {
+    try await EppoClient.initialize(
+        sdkKey: "SDK-KEY-FROM-DASHBOARD",
+        forceReinitialize: true
+    );
+}
+```
+
 #### Assign anywhere
 
 Assignment is a synchronous operation.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ If you'd like to initialize Eppo's client without performing a network request, 
 
 ```swift
 try EppoClient.initialize(
-    configurationJson: "PRE-FETCHED-CONFIGURATION-JSON",
-    obfuscated: false
+    configurationJson: "{ \"pre-loaded-JSON\": \"passed in here\" }",
+    obfuscated: false,
+    sdkKey: "SDK-KEY-FROM-DASHBOARD"
 );
 ```
 
@@ -55,24 +56,22 @@ The `obfuscated` parameter is used to inform the SDK if the flag configuration i
 
 The initialization method is synchronous and allows you to perform assignments immediately.
 
-**(Optional) Fetching the configuration from the remote source on-demand.**
+#### (Optional) Fetching the configuration from the remote source on-demand.**
 
 Combine both initialization methods to start your application with a local configuration and then 
 asynchronously fetch the latest flag configuration from the remote source.
 
 ```swift
 try EppoClient.initialize(
-    configurationJson: "PRE-FETCHED-CONFIGURATION-JSON",
+    configurationJson: "{ \"pre-loaded-JSON\": \"passed in here\" }",
     obfuscated: false,
+    sdkKey: "SDK-KEY-FROM-DASHBOARD",
 );
 
 ...
 
 Task {
-    try await EppoClient.initialize(
-        sdkKey: "SDK-KEY-FROM-DASHBOARD",
-        forceReinitialize: true
-    );
+    try await EppoClient.shared().load();
 }
 ```
 

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -2,7 +2,11 @@ import Foundation;
 
 let UFC_CONFIG_URL = "/api/flag-config/v1/config"
 
-class ConfigurationRequester {
+protocol ConfigurationRequesterProtocol {
+    func fetchConfigurations() async throws -> UniversalFlagConfig
+}
+
+class HttpConfigurationRequester: ConfigurationRequesterProtocol {
     private let httpClient: EppoHttpClient;
 
     public init(httpClient: EppoHttpClient) {
@@ -12,5 +16,17 @@ class ConfigurationRequester {
     public func fetchConfigurations() async throws -> UniversalFlagConfig {
         let (urlData, _) = try await httpClient.get(UFC_CONFIG_URL);
         return try UniversalFlagConfig.decodeFromJSON(from: String(data: urlData, encoding: .utf8)!);
+    }
+}
+
+class JsonConfigurationRequester: ConfigurationRequesterProtocol {
+    private let configurationJson: String;
+
+    public init(configurationJson: String) {
+        self.configurationJson = configurationJson
+    }
+
+    public func fetchConfigurations() throws -> UniversalFlagConfig {
+        return try UniversalFlagConfig.decodeFromJSON(from: configurationJson);
     }
 }

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -1,19 +1,12 @@
 import Foundation
 
 class ConfigurationStore {
-    private let requester: ConfigurationRequesterProtocol
     private var flagConfigs: UniversalFlagConfig?
     private let syncQueue = DispatchQueue(
         label: "com.eppo.configurationStoreQueue", attributes: .concurrent)
     
-    public init(requester: ConfigurationRequesterProtocol) {
-        self.requester = requester
+    public init() {
         self.flagConfigs = UniversalFlagConfig(createdAt: nil, flags: [:])
-    }
-
-    public func fetchAndStoreConfigurations() async throws {
-        let config = try await self.requester.fetchConfigurations()
-        self.setConfigurations(config: config)
     }
 
     // Get the configuration for a given flag key in a thread-safe manner.

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 class ConfigurationStore {
-    private let requester: ConfigurationRequester
+    private let requester: ConfigurationRequesterProtocol
     private var flagConfigs: UniversalFlagConfig?
     private let syncQueue = DispatchQueue(
         label: "com.eppo.configurationStoreQueue", attributes: .concurrent)
     
-    public init(requester: ConfigurationRequester) {
+    public init(requester: ConfigurationRequesterProtocol) {
         self.requester = requester
         self.flagConfigs = UniversalFlagConfig(createdAt: nil, flags: [:])
     }

--- a/Tests/eppo/ConfigurationRequesterTests.swift
+++ b/Tests/eppo/ConfigurationRequesterTests.swift
@@ -1,20 +1,57 @@
 import XCTest
 @testable import eppo_flagging
 
-class ConfigurationRequesterTests: XCTestCase {
+class HttpConfigurationRequesterTests: XCTestCase {
     var httpClientMock: EppoHttpClientMock!
-    var configurationRequester: ConfigurationRequester!
+    var configurationRequester: HttpConfigurationRequester!
 
     override func setUp() {
         super.setUp()
         httpClientMock = EppoHttpClientMock()
-        configurationRequester = ConfigurationRequester(httpClient: httpClientMock)
+        configurationRequester = HttpConfigurationRequester(httpClient: httpClientMock)
     }
 
     override func tearDown() {
         httpClientMock = nil
         configurationRequester = nil
         super.tearDown()
+    }
+}
+
+class JsonConfigurationRequesterTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testJsonConfigurationRequester_ValidConfig() async throws {
+        let validJson = """
+        {
+          "createdAt": "2024-04-17T19:40:53.716Z",
+          "environment": {
+            "name": "Test"
+          },
+          "flags": {
+            "empty_flag": {
+              "key": "empty_flag",
+              "enabled": true,
+              "variationType": "STRING",
+              "variations": {},
+              "allocations": [],
+              "totalShards": 10000
+            }
+          }
+        }
+        """
+        let requester = JsonConfigurationRequester(configurationJson: validJson)
+        
+        let config = try requester.fetchConfigurations()
+        
+        XCTAssertEqual(config.flags.count, 1)
+        XCTAssertEqual(config.flags.keys.first, "empty_flag")
     }
 }
 

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class ConfigurationStoreTests: XCTestCase {
     var configurationStore: ConfigurationStore!
-    var mockRequester: ConfigurationRequester!
+    var mockRequester: ConfigurationRequesterProtocol!
     var configs: UniversalFlagConfig!
     
     let emptyFlagConfig = UFC_Flag(
@@ -18,7 +18,7 @@ final class ConfigurationStoreTests: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        mockRequester = ConfigurationRequester(httpClient: EppoHttpClientMock())
+        mockRequester = HttpConfigurationRequester(httpClient: EppoHttpClientMock())
         configurationStore = ConfigurationStore(requester: mockRequester)
         
         configs = UniversalFlagConfig(

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -19,7 +19,7 @@ final class ConfigurationStoreTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockRequester = HttpConfigurationRequester(httpClient: EppoHttpClientMock())
-        configurationStore = ConfigurationStore(requester: mockRequester)
+        configurationStore = ConfigurationStore()
         
         configs = UniversalFlagConfig(
             createdAt: nil,

--- a/Tests/eppo/EppoClientDataTests.swift
+++ b/Tests/eppo/EppoClientDataTests.swift
@@ -78,6 +78,7 @@ final class EppoClientDataTests: XCTestCase {
         
         if useJsonString {
             eppoClient = try EppoClient.initialize(
+                sdkKey: "mock-api-key",
                 configurationJson: configurationJson,
                 obfuscated: obfuscated,
                 assignmentLogger: loggerSpy.logger

--- a/Tests/eppo/OfflineClientTests.swift
+++ b/Tests/eppo/OfflineClientTests.swift
@@ -9,6 +9,11 @@ final class OfflineClientTests: XCTestCase {
     var loggerSpy: AssignmentLoggerSpy!
     var eppoClient: EppoClient!
     
+    override func setUp() {
+        super.setUp()
+        EppoClient.resetSharedInstance()
+    }
+    
     // Test initializing EppoClient with a local JSON string, performing an assignment,
     // then initializing with a stubbed remote JSON and performing a different assignment.
     func testInitializationWithLocalAndRemoteJSONAssignments() async throws {
@@ -44,6 +49,7 @@ final class OfflineClientTests: XCTestCase {
         
         // Initialize EppoClient with local JSON
         eppoClient = try EppoClient.initialize(
+            sdkKey: "mock-api-key",
             configurationJson: localJsonString,
             obfuscated: false,
             assignmentLogger: loggerSpy?.logger
@@ -67,33 +73,33 @@ final class OfflineClientTests: XCTestCase {
             "name": "Test"
           },
           "flags": {
-            "numeric_flag": {
-              "key": "numeric_flag",
+            "2c27190d8645fe3bc3c1d63b31f0e4ee": {
+              "key": "2c27190d8645fe3bc3c1d63b31f0e4ee",
               "enabled": true,
               "variationType": "NUMERIC",
+              "totalShards": 10000,
               "variations": {
-                "e": {
-                  "key": "e",
-                  "value": 2.7182818
+                "ZQ==": {
+                  "key": "ZQ==",
+                  "value": "Mi43MTgyODE4"
                 },
-                "pi": {
-                  "key": "pi",
-                  "value": 3.1415926
+                "cGk=": {
+                  "key": "cGk=",
+                  "value": "My4xNDE1OTI2"
                 }
               },
               "allocations": [
                 {
-                  "key": "rollout",
+                  "key": "cm9sbG91dA==",
+                  "doLog": true,
                   "splits": [
                     {
-                      "variationKey": "pi",
+                      "variationKey": "cGk=",
                       "shards": []
                     }
-                  ],
-                  "doLog": true
+                  ]
                 }
-              ],
-              "totalShards": 10000
+              ]
             }
           }
         }
@@ -105,12 +111,8 @@ final class OfflineClientTests: XCTestCase {
         }
         
         // Step 3: Re-initialize EppoClient to fetch remote configurations
-        eppoClient = try await EppoClient.initialize(
-            sdkKey: "mock-api-key",
-            assignmentLogger: loggerSpy?.logger,
-            forceReinitialize: true
-        )
-        eppoClient.setConfigObfuscation(obfuscated: false)
+        eppoClient.takeOnline(sdkKey: "mock-api-key")
+        try await eppoClient.load()
         
         // Perform a different assignment with the updated client
         let updatedAssignment = try eppoClient.getNumericAssignment(

--- a/Tests/eppo/OfflineClientTests.swift
+++ b/Tests/eppo/OfflineClientTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable import eppo_flagging
+
+final class OfflineClientTests: XCTestCase {
+    var loggerSpy: AssignmentLoggerSpy!
+    var eppoClient: EppoClient!
+    
+    // Test initializing EppoClient with a local JSON string, performing an assignment,
+    // then initializing with a stubbed remote JSON and performing a different assignment.
+    func testInitializationWithLocalAndRemoteJSONAssignments() async throws {
+        // Step 1: Initialize with local JSON string
+        // No allocations.
+        let localJsonString = """
+        {
+          "createdAt": "2024-04-17T19:40:53.716Z",
+          "environment": {
+            "name": "Test"
+          },
+          "flags": {
+            "numeric_flag": {
+              "key": "numeric_flag",
+              "enabled": true,
+              "variationType": "NUMERIC",
+              "variations": {
+                "e": {
+                  "key": "e",
+                  "value": 2.7182818
+                },
+                "pi": {
+                  "key": "pi",
+                  "value": 3.1415926
+                }
+              },
+              "allocations": [],
+              "totalShards": 10000
+            }
+          }
+        }
+        """
+        
+        // Initialize EppoClient with local JSON
+        eppoClient = try EppoClient.initialize(
+            configurationJson: localJsonString,
+            obfuscated: false,
+            assignmentLogger: loggerSpy?.logger
+        )
+        
+        // Perform an assignment with the initial client
+        let initialAssignment = try eppoClient.getNumericAssignment(
+            flagKey: "numeric_flag",
+            subjectKey: "alice",
+            defaultValue: 100
+        )
+        
+        // Verify the initial assignment
+        XCTAssertEqual(initialAssignment, 100, "initial configuration has no allocations; return default value")
+        
+        // Step 2: Stub the remote JSON response
+        let remoteJsonString = """
+        {
+          "createdAt": "2024-04-17T19:40:53.716Z",
+          "environment": {
+            "name": "Test"
+          },
+          "flags": {
+            "numeric_flag": {
+              "key": "numeric_flag",
+              "enabled": true,
+              "variationType": "NUMERIC",
+              "variations": {
+                "e": {
+                  "key": "e",
+                  "value": 2.7182818
+                },
+                "pi": {
+                  "key": "pi",
+                  "value": 3.1415926
+                }
+              },
+              "allocations": [
+                {
+                  "key": "rollout",
+                  "splits": [
+                    {
+                      "variationKey": "pi",
+                      "shards": []
+                    }
+                  ],
+                  "doLog": true
+                }
+              ],
+              "totalShards": 10000
+            }
+          }
+        }
+        """
+        
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let stubData = remoteJsonString.data(using: .utf8)!
+            return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Step 3: Re-initialize EppoClient to fetch remote configurations
+        eppoClient = try await EppoClient.initialize(
+            sdkKey: "mock-api-key",
+            assignmentLogger: loggerSpy?.logger,
+            forceReinitialize: true
+        )
+        eppoClient.setConfigObfuscation(obfuscated: false)
+        
+        // Perform a different assignment with the updated client
+        let updatedAssignment = try eppoClient.getNumericAssignment(
+            flagKey: "numeric_flag",
+            subjectKey: "alice",
+            defaultValue: 100
+        )
+        
+        // Verify the updated assignment
+        XCTAssertEqual(updatedAssignment, 3.1415926, "Updated assignment uses variation value.")
+    }
+}


### PR DESCRIPTION
…uration] (FF-3242)

## Customer requirement

1. Provide a json UFC configuration to the SDK and synchronously put it into a mode available for assignment. This is useful for when the configuration is downloaded from an external process and passed to the mobile device over an internal API. Alternatively it can be the pass that a UFC configuration is packaged with the local build.
2. After initializing with a static configuration, users want to (optionally) be able to fetch configuration from the remote CDN.

**Design question**

The ability to set static configuration is separated from loading the remote configuration. The main benefit here is for the former to be a sync method and make the SDK immediately available.

Customers might want to then follow up by loading a remote configuration if the packaged configuration is stale. Others who provide the configuration over their internal API from a server process will be satisfied with it.

The only re-render should occur after the remote configuration is loaded.

## Changes

Adds a `initialize` method which is synchronous and takes as its inputs a json string of the UFC configuration, whether the format is obfuscated and the usual assignment logger and assignment cache.

The `ConfigurationRequester` is refactored into an interface (`protocol` in swift) and a new implementation handles inputing the json string and decoding it from JSON. The [json decode ](https://github.com/Eppo-exp/eppo-ios-sdk/blob/main/Sources/eppo/UniversalFlagConfig.swift#L24-L42)is already well tested with appropriate error messages for various errors.

During sync init, the configuration store is set atomically and safely (using existing methods) and the SDK put into `offline mode`, which means the SDK key and host parameter is are not validated to be set.

## Follow-ups

* Add a persistent cache to the swift sdk

## Testing

* Refactored the data tests to execute both initialization from a network request (stubbed) or from json string.
* demonstrates that a configuration can be sync loaded, assignment working, remote reloaded and assignment updated