### PR TITLE
FF-3242 feat: support passing initial configuration and offline initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ Task {
 }
 ```
 
+Optionally, you can pass in a pre-fetched configuration JSON string.
+
+```swift
+Task {
+    try await EppoClient.initialize(
+        sdkKey: "SDK-KEY-FROM-DASHBOARD",
+        initialConfiguration: try Configuration(
+            flagsConfigurationJson: Data(#"{ "pre-loaded-JSON": "passed in here" }"#.utf8),
+            obfuscated: false
+        )
+    );
+}
+
+In both cases the SDK will perform a network request to fetch the latest flag configurations.
+
 #### Offline initialization
 
 If you'd like to initialize Eppo's client without performing a network request, you can pass in a pre-fetched configuration JSON string.
@@ -78,6 +93,9 @@ Task {
 }
 ```
 
+As modern iOS devices have substantial memory, applications are often kept in memory across sessions. This means that the flag configurations are not automatically reloaded on subsequent launches.
+
+It is recommended to use the `load()` method to fetch the latest flag configurations when the application is launched.
 
 #### Assign anywhere
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,45 @@ Task {
 }
 ```
 
+#### Offline initialization
+
+If you'd like to initialize Eppo's client without performing a network request, you can pass in a pre-fetched configuration JSON string.
+
+```swift
+try EppoClient.initializeOffline(
+    sdkKey: "SDK-KEY-FROM-DASHBOARD",
+    initialConfiguration: try Configuration(
+        flagsConfigurationJson: Data(#"{ "pre-loaded-JSON": "passed in here" }"#.utf8),
+        obfuscated: false
+    )
+);
+```
+
+The `obfuscated` parameter is used to inform the SDK if the flag configuration is obfuscated.
+
+The initialization method is synchronous and allows you to perform assignments immediately.
+
+#### (Optional) Fetching the configuration from the remote source on-demand.**
+
+After the client has been initialized, you can use `load()` to asynchronously fetch the latest flag configuration from the remote source.
+
+```swift
+try EppoClient.initializeOffline(
+    sdkKey: "SDK-KEY-FROM-DASHBOARD",
+    initialConfiguration: try Configuration(
+        flagsConfigurationJson: Data(#"{ "pre-loaded-JSON": "passed in here" }"#.utf8),
+        obfuscated: false
+    )
+);
+
+...
+
+Task {
+    try await EppoClient.shared().load();
+}
+```
+
+
 #### Assign anywhere
 
 Assignment is a synchronous operation.

--- a/Sources/eppo/Configuration.swift
+++ b/Sources/eppo/Configuration.swift
@@ -2,14 +2,20 @@ import Foundation
 
 public struct Configuration {
     internal let flagsConfiguration: UniversalFlagConfig;
+    internal let obfuscated: Bool;
 
 
-    internal init(flagsConfiguration: UniversalFlagConfig) {
+    internal init(flagsConfiguration: UniversalFlagConfig, obfuscated: Bool) {
         self.flagsConfiguration = flagsConfiguration
+        self.obfuscated = obfuscated
     }
 
-    public init(flagsConfigurationJson: Data) throws {
+    public init(flagsConfigurationJson: Data, obfuscated: Bool) throws {
         let flagsConfiguration = try UniversalFlagConfig.decodeFromJSON(from: flagsConfigurationJson);
-        self.init(flagsConfiguration: flagsConfiguration)
+        self.init(flagsConfiguration: flagsConfiguration, obfuscated: obfuscated)
+    }
+
+    internal func getFlag(flagKey: String) -> UFC_Flag? {
+        return self.flagsConfiguration.flags[flagKey]
     }
 }

--- a/Sources/eppo/Configuration.swift
+++ b/Sources/eppo/Configuration.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Configuration {
+    internal let flagsConfiguration: UniversalFlagConfig;
+
+
+    internal init(flagsConfiguration: UniversalFlagConfig) {
+        self.flagsConfiguration = flagsConfiguration
+    }
+
+    public init(flagsConfigurationJson: Data) throws {
+        let flagsConfiguration = try UniversalFlagConfig.decodeFromJSON(from: flagsConfigurationJson);
+        self.init(flagsConfiguration: flagsConfiguration)
+    }
+}

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -11,6 +11,6 @@ class ConfigurationRequester {
 
     public func fetchConfigurations() async throws -> Configuration {
         let (data, _) = try await httpClient.get(UFC_CONFIG_URL);
-        return try Configuration(flagsConfigurationJson: data);
+        return try Configuration(flagsConfigurationJson: data, obfuscated: true);
     }
 }

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -9,8 +9,8 @@ class ConfigurationRequester {
         self.httpClient = httpClient
     }
 
-    public func fetchConfigurations() async throws -> UniversalFlagConfig {
-        let (urlData, _) = try await httpClient.get(UFC_CONFIG_URL);
-        return try UniversalFlagConfig.decodeFromJSON(from: String(data: urlData, encoding: .utf8)!);
+    public func fetchConfigurations() async throws -> Configuration {
+        let (data, _) = try await httpClient.get(UFC_CONFIG_URL);
+        return try Configuration(flagsConfigurationJson: data);
     }
 }

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -27,10 +27,4 @@ class ConfigurationStore {
             self.configuration = configuration
         }
     }
-    
-    public func isInitialized() -> Bool {
-        return syncQueue.sync {
-            self.configuration != nil
-        }
-    }
 }

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -3,17 +3,10 @@ import Foundation
 class ConfigurationStore {
     private var configuration: Configuration?
     
-    private let requester: ConfigurationRequester
     private let syncQueue = DispatchQueue(
         label: "com.eppo.configurationStoreQueue", attributes: .concurrent)
     
-    public init(requester: ConfigurationRequester) {
-        self.requester = requester
-    }
-
-    public func fetchAndStoreConfigurations() async throws {
-        let config = try await self.requester.fetchConfigurations()
-        self.setConfiguration(configuration: config)
+    public init() {
     }
 
     // Get the configuration for a given flag key in a thread-safe manner.
@@ -32,7 +25,7 @@ class ConfigurationStore {
     // operations on the `flagConfigs` can proceed. This guarantees that the configuration state is
     // consistent and prevents race conditions where reads could see a partially updated state.
     public func setConfiguration(configuration: Configuration) {
-        syncQueue.async(flags: .barrier) {
+        syncQueue.asyncAndWait(flags: .barrier) {
             self.configuration = configuration
         }
     }

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -13,10 +13,8 @@ class ConfigurationStore {
     //
     // The use of a syncQueue ensures that this read operation is thread-safe and doesn't cause
     // race conditions where reads could see a partially updated state.
-    public func getConfiguration(flagKey: String) -> UFC_Flag? {
-        return syncQueue.sync {
-            self.configuration?.flagsConfiguration.flags[flagKey]
-        }
+    public func getConfiguration() -> Configuration? {
+        return syncQueue.sync { self.configuration }
     }
     
     // Set the configurations in a thread-safe manner.

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -4,6 +4,8 @@ import Foundation;
 public let sdkName = "ios"
 public let sdkVersion = "3.1.0"
 
+public let defaultHost = "https://fscdn.eppo.cloud"
+
 public enum Errors: Error {
     case notConfigured
     case sdkKeyInvalid
@@ -74,7 +76,7 @@ public class EppoClient {
     /// Configuration can later be loaded with `load()` method.
     public static func initializeOffline(
         sdkKey: String,
-        host: String = "https://fscdn.eppo.cloud",
+        host: String = defaultHost,
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         initialConfiguration: Configuration?
@@ -98,7 +100,7 @@ public class EppoClient {
     
     public static func initialize(
         sdkKey: String,
-        host: String = "https://fscdn.eppo.cloud",
+        host: String = defaultHost,
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         initialConfiguration: Configuration? = nil

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -2,7 +2,7 @@ import Foundation;
 
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "3.1.0"
+public let sdkVersion = "3.2.0"
 
 public let defaultHost = "https://fscdn.eppo.cloud"
 

--- a/Sources/eppo/UniversalFlagConfig.swift
+++ b/Sources/eppo/UniversalFlagConfig.swift
@@ -4,11 +4,7 @@ public struct UniversalFlagConfig : Decodable {
     let createdAt: Date?;
     let flags: [String: UFC_Flag];
     
-    static func decodeFromJSON(from jsonString: String) throws -> UniversalFlagConfig {
-        guard let jsonData = jsonString.data(using: .utf8) else {
-            throw UniversalFlagConfigError.notUTF8Encoded("Failed to encode JSON string into UTF-8 data.")
-        }
-        
+    static func decodeFromJSON(from json: Data) throws -> UniversalFlagConfig {
         let decoder = JSONDecoder()
         
         // Dates could be in base64 encoded format or not
@@ -22,7 +18,7 @@ public struct UniversalFlagConfig : Decodable {
         }
         
         do {
-            return try decoder.decode(UniversalFlagConfig.self, from: jsonData)
+            return try decoder.decode(UniversalFlagConfig.self, from: json)
         } catch let error as DecodingError {
             switch error {
             case .typeMismatch(_, let context):

--- a/Tests/eppo/AssignmentLoggerTests.swift
+++ b/Tests/eppo/AssignmentLoggerTests.swift
@@ -10,7 +10,7 @@ import OHHTTPStubsSwift
 final class AssignmentLoggerTests: XCTestCase {
    var loggerSpy: AssignmentLoggerSpy!
    var eppoClient: EppoClient!
-   var UFCTestJSON: String!
+   var UFCTestJSON: Data!
    
    override func setUpWithError() throws {
        try super.setUpWithError()
@@ -18,11 +18,11 @@ final class AssignmentLoggerTests: XCTestCase {
        let fileURL = Bundle.module.url(
            forResource: "Resources/test-data/ufc/flags-v1-obfuscated.json",
            withExtension: ""
-       )
-       UFCTestJSON = try! String(contentsOfFile: fileURL!.path)
+       )!
+       UFCTestJSON = try! Data(contentsOf: fileURL)
 
        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
-           let stubData = self.UFCTestJSON.data(using: .utf8)!
+           let stubData = self.UFCTestJSON!
            return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
        }
        

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -19,19 +19,22 @@ final class ConfigurationStoreTests: XCTestCase {
         try super.setUpWithError()
         configurationStore = ConfigurationStore()
         
-        configuration = Configuration(flagsConfiguration: UniversalFlagConfig(
+        configuration = Configuration(
+          flagsConfiguration: UniversalFlagConfig(
             createdAt: nil,
             flags: [
-                "testFlag": emptyFlagConfig
+              "testFlag": emptyFlagConfig
             ]
-        ))
+          ),
+          obfuscated: false
+        )
     }
     
     func testSetAndGetConfiguration() throws {
         configurationStore.setConfiguration(configuration: configuration)
         
         XCTAssertEqual(
-            configurationStore.getConfiguration(flagKey: "testFlag")?.enabled, emptyFlagConfig.enabled)
+          configurationStore.getConfiguration()?.getFlag(flagKey: "testFlag")?.enabled, emptyFlagConfig.enabled)
     }
     
     func testIsInitialized() async throws {

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 final class ConfigurationStoreTests: XCTestCase {
     var configurationStore: ConfigurationStore!
-    var mockRequester: ConfigurationRequester!
     var configuration: Configuration!
     
     let emptyFlagConfig = UFC_Flag(
@@ -18,8 +17,7 @@ final class ConfigurationStoreTests: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        mockRequester = ConfigurationRequester(httpClient: EppoHttpClientMock())
-        configurationStore = ConfigurationStore(requester: mockRequester)
+        configurationStore = ConfigurationStore()
         
         configuration = Configuration(flagsConfiguration: UniversalFlagConfig(
             createdAt: nil,

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class ConfigurationStoreTests: XCTestCase {
     var configurationStore: ConfigurationStore!
     var mockRequester: ConfigurationRequester!
-    var configs: UniversalFlagConfig!
+    var configuration: Configuration!
     
     let emptyFlagConfig = UFC_Flag(
         key: "empty",
@@ -21,17 +21,16 @@ final class ConfigurationStoreTests: XCTestCase {
         mockRequester = ConfigurationRequester(httpClient: EppoHttpClientMock())
         configurationStore = ConfigurationStore(requester: mockRequester)
         
-        configs = UniversalFlagConfig(
+        configuration = Configuration(flagsConfiguration: UniversalFlagConfig(
             createdAt: nil,
             flags: [
                 "testFlag": emptyFlagConfig
             ]
-        )
+        ))
     }
     
     func testSetAndGetConfiguration() throws {
-        // Pass the RACConfig object to setConfigurations
-        configurationStore.setConfigurations(config: configs)
+        configurationStore.setConfiguration(configuration: configuration)
         
         XCTAssertEqual(
             configurationStore.getConfiguration(flagKey: "testFlag")?.enabled, emptyFlagConfig.enabled)
@@ -42,7 +41,7 @@ final class ConfigurationStoreTests: XCTestCase {
             configurationStore.isInitialized(),
             "Store should not be initialized before fetching configurations")
         
-        configurationStore.setConfigurations(config: configs)
+        configurationStore.setConfiguration(configuration: configuration)
         
         XCTAssertTrue(
             configurationStore.isInitialized(),

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -38,14 +38,14 @@ final class ConfigurationStoreTests: XCTestCase {
     }
     
     func testIsInitialized() async throws {
-        XCTAssertFalse(
-            configurationStore.isInitialized(),
+        XCTAssertNil(
+            configurationStore.getConfiguration(),
             "Store should not be initialized before fetching configurations")
         
         configurationStore.setConfiguration(configuration: configuration)
         
-        XCTAssertTrue(
-            configurationStore.isInitialized(),
+        XCTAssertNotNil(
+            configurationStore.getConfiguration(),
             "Store should be initialized after fetching configurations")
     }
     

--- a/Tests/eppo/OfflineClientTests.swift
+++ b/Tests/eppo/OfflineClientTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable import eppo_flagging
+
+final class OfflineClientTests: XCTestCase {
+    var loggerSpy: AssignmentLoggerSpy!
+    var eppoClient: EppoClient!
+    
+    override func setUp() {
+        super.setUp()
+        EppoClient.resetSharedInstance()
+    }
+    
+    // Test initializing EppoClient with a local JSON string, performing an assignment,
+    // then initializing with a stubbed remote JSON and performing a different assignment.
+    func testInitializationWithLocalAndRemoteJSONAssignments() async throws {
+        // Step 1: Initialize with local JSON string
+        // No allocations.
+        let localJsonString = """
+        {
+          "createdAt": "2024-04-17T19:40:53.716Z",
+          "environment": {
+            "name": "Test"
+          },
+          "flags": {
+            "numeric_flag": {
+              "key": "numeric_flag",
+              "enabled": true,
+              "variationType": "NUMERIC",
+              "variations": {
+                "e": {
+                  "key": "e",
+                  "value": 2.7182818
+                },
+                "pi": {
+                  "key": "pi",
+                  "value": 3.1415926
+                }
+              },
+              "allocations": [],
+              "totalShards": 10000
+            }
+          }
+        }
+        """
+        
+        // Initialize EppoClient with local JSON
+        eppoClient = EppoClient.initializeOffline(
+            sdkKey: "mock-api-key",
+            assignmentLogger: loggerSpy?.logger,
+            initialConfiguration: try Configuration(
+                flagsConfigurationJson: Data(localJsonString.utf8),
+                obfuscated: false
+            )
+        )
+        
+        // Perform an assignment with the initial client
+        let initialAssignment = try eppoClient.getNumericAssignment(
+            flagKey: "numeric_flag",
+            subjectKey: "alice",
+            defaultValue: 100
+        )
+        
+        // Verify the initial assignment
+        XCTAssertEqual(initialAssignment, 100, "initial configuration has no allocations; return default value")
+        
+        // Step 2: Stub the remote JSON response
+        let remoteJsonString = """
+        {
+          "createdAt": "2024-04-17T19:40:53.716Z",
+          "environment": {
+            "name": "Test"
+          },
+          "flags": {
+            "2c27190d8645fe3bc3c1d63b31f0e4ee": {
+              "key": "2c27190d8645fe3bc3c1d63b31f0e4ee",
+              "enabled": true,
+              "variationType": "NUMERIC",
+              "totalShards": 10000,
+              "variations": {
+                "ZQ==": {
+                  "key": "ZQ==",
+                  "value": "Mi43MTgyODE4"
+                },
+                "cGk=": {
+                  "key": "cGk=",
+                  "value": "My4xNDE1OTI2"
+                }
+              },
+              "allocations": [
+                {
+                  "key": "cm9sbG91dA==",
+                  "doLog": true,
+                  "splits": [
+                    {
+                      "variationKey": "cGk=",
+                      "shards": []
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """
+        
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let stubData = remoteJsonString.data(using: .utf8)!
+            return HTTPStubsResponse(data: stubData, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Step 3: Re-initialize EppoClient to fetch remote configurations
+        try await eppoClient.load()
+        
+        // Perform a different assignment with the updated client
+        let updatedAssignment = try eppoClient.getNumericAssignment(
+            flagKey: "numeric_flag",
+            subjectKey: "alice",
+            defaultValue: 100
+        )
+        
+        // Verify the updated assignment
+        XCTAssertEqual(updatedAssignment, 3.1415926, "Updated assignment uses variation value.")
+    }
+}

--- a/Tests/eppo/UniversalFlagConfigTests.swift
+++ b/Tests/eppo/UniversalFlagConfigTests.swift
@@ -7,14 +7,14 @@ import Foundation
 final class UniversalFlagConfigTest: XCTestCase {
     func testDecodeUFCConfig() {
         var fileURL: URL!
-        var UFCTestJSON: String!
+        var UFCTestJSON: Data!
         
         fileURL = Bundle.module.url(
             forResource: "Resources/test-data/ufc/flags-v1.json",
             withExtension: ""
         )
         do {
-            UFCTestJSON = try String(contentsOfFile: fileURL.path)
+            UFCTestJSON = try Data(contentsOf: fileURL)
         } catch {
             XCTFail("Error loading test JSON: \(error)")
         }
@@ -43,14 +43,14 @@ final class UniversalFlagConfigTest: XCTestCase {
     
     func testDecodeObfuscatedUFCConfig() {
         var fileURL: URL!
-        var UFCTestJSON: String!
+        var UFCTestJSON: Data!
         
         fileURL = Bundle.module.url(
             forResource: "Resources/test-data/ufc/flags-v1-obfuscated.json",
             withExtension: ""
         )
         do {
-            UFCTestJSON = try String(contentsOfFile: fileURL.path)
+            UFCTestJSON = try Data(contentsOf: fileURL)
         } catch {
             XCTFail("Error loading test JSON: \(error)")
         }
@@ -85,7 +85,7 @@ final class UniversalFlagConfigTest: XCTestCase {
     // todo: add a test for not utf8 encoded values. need to figure out how to implement this.
 
     func testUnableToDecodeJSON() {
-        let invalidJSON = "invalid_json"
+        let invalidJSON = "invalid_json".data(using: .utf8)!
         XCTAssertThrowsError(try UniversalFlagConfig.decodeFromJSON(from: invalidJSON)) { error in
             guard let thrownError = error as? UniversalFlagConfigError else {
                 XCTFail("Error should be of type UniversalFlagConfigError")


### PR DESCRIPTION
This adds support for passing initial configuration in initialize and offline initialization method. In a sense, they are two orthogonal features often used together.

Overview of the changes:
- Decouple `ConfigurationStore` from `ConfigurationRequester`
- Introduce `Configuration` type that encapsulates everything we need to know about configuration: flags configuration and whether it's obfuscated (+ will add bandits configuration in the future). `ConfigurationStore` now just stores a single instance of configuration atomically.
- Add `initializeOffline` method that works the same as regular initialization but does not request a configuration
- Add `initialConfiguration` parameter to initialization methods. If passed, it initializes configuration store with that value
- Fix data race accessing `sharedInstance` (reads were not properly guarded)