### PR TITLE
#43 improvements

### DIFF
--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -18,8 +18,8 @@ final class ConfigurationStoreTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         // Create a new instance for each test
+        ConfigurationStore.clearPersistentCache()
         configurationStore = ConfigurationStore()
-        configurationStore.clearPersistentCache()
         
         configuration = Configuration(
           flagsConfiguration: UniversalFlagConfig(
@@ -43,8 +43,8 @@ final class ConfigurationStoreTests: XCTestCase {
         configurationStore.setConfiguration(configuration: configuration)
         XCTAssertNotNil(configurationStore.getConfiguration(), "Configuration should be set")
         
-        configurationStore.clearPersistentCache()
-        XCTAssertNil(configurationStore.getConfiguration(), "Configuration should be nil after clearing cache")
+        ConfigurationStore.clearPersistentCache()
+        XCTAssertNotNil(configurationStore.getConfiguration(), "Configuration should not be nil after clearing cache")
     }
 
     func testSetAndGetConfiguration() throws {


### PR DESCRIPTION
1. Make caching optional and handle the case of absent / non-writable cache directory
2. Move cache saving to background, so it does not slow configuration assignment
3. Make `clearPersistentCache()` not clear configuration. From a user perspective, I would expect this function to only clear the cache