### PR TITLE
bug: replace usages of DispatchQueue.asyncAndWait with DispatchQueue async. (FF-3331)

### DIFF
--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 class ConfigurationStore {
+    // CAUTION! 
+    // 
+    // Take care before changing the DispatchQueue methods to `asyncOrWait`
+    // as we previously had a bug related to support across older iOS versions.
+    // https://github.com/Eppo-exp/eppo-ios-sdk/issues/46
+
     private var configuration: Configuration?
     private let syncQueue = DispatchQueue(
         label: "com.eppo.configurationStoreQueue", attributes: .concurrent)

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -65,7 +65,7 @@ class ConfigurationStore {
     // operations on the `flagConfigs` can proceed. This guarantees that the configuration state is
     // consistent and prevents race conditions where reads could see a partially updated state.
     public func setConfiguration(configuration: Configuration) {
-        syncQueue.asyncAndWait(flags: .barrier) {
+        syncQueue.sync(flags: .barrier) {
             self.configuration = configuration
             self.saveToDisk(configuration: configuration)
         }
@@ -76,7 +76,7 @@ class ConfigurationStore {
             return
         }
 
-        Self.persistenceQueue.asyncAndWait {
+        Self.persistenceQueue.sync {
             do {
                 try FileManager.default.removeItem(at: cacheFileURL)
             } catch {

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -2,7 +2,7 @@ import Foundation;
 
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "3.3.0"
+public let sdkVersion = "3.3.1"
 
 public let defaultHost = "https://fscdn.eppo.cloud"
 


### PR DESCRIPTION
## Motivation

Customer reports of crashes due to missing library: https://github.com/Eppo-exp/eppo-ios-sdk/issues/46

## Reproduction

We were able to reproduce the crashes on Simulators running ios `15.5` and `16.0`, the issue does not manifest on versions `17.0` and higher.

### ✖️ 15.5
<img width="1435" alt="repro - ios 15 5" src="https://github.com/user-attachments/assets/6b981513-5952-405c-a231-ea6c259acd9e">

### ✖️ 16.0
<img width="1435" alt="repro - ios 16 0" src="https://github.com/user-attachments/assets/0d34f042-6acc-4e4a-b406-1965de8830c3">

### ✔️ 17.5

<img width="1435" alt="repro - ios 17 5" src="https://github.com/user-attachments/assets/991c4da4-8128-4ae7-a819-50ad4388fbbe">

### ✔️ 18.0

<img width="1435" alt="repro - ios 18 0" src="https://github.com/user-attachments/assets/d087ea5f-4cf3-41e8-ba31-5f0eaa840b54">

## Implementation changes

Replaces usage of `DispatchQueue.async` with `DispatchQueue.sync` - the latter is known to be supported across our desired iOS SDK versions.

* https://developer.apple.com/documentation/dispatch/dispatchqueue/3191901-asyncandwait
* https://developer.apple.com/documentation/dispatch/dispatchqueue/2016083-sync

## SDK behavior changes

There will be impact on performance, latency, and time to first pixel (TTFP) when the app starts and attempts to load the configuration from disk. We need to trade this off against a widely available API and stable SDK.

When `asyncAndWait` is used, the operation is dispatched asynchronously to the queue but waits for the task to finish before proceeding. This non-blocking approach allows other tasks on the calling thread to continue executing while waiting for the completion of the task.

Using asyncAndWait allows for non-blocking concurrency, which can help reduce overall latency, especially on systems where multiple tasks need to run concurrently (e.g., during app startup). This would help improve time to first pixel (TTFP) because the UI or other tasks could still progress while waiting for the configuration to be loaded or written to disk.

👉 After replacing asyncAndWait with sync, the operations on the queues now execute synchronously, meaning the current thread waits (is blocked) until the task completes. No other tasks can proceed on the current thread while these operations are happening.

Using sync means the disk operations (e.g., setting configuration or clearing cache) will block the thread until the task is finished. This can increase overall latency, especially if disk I/O operations are slow, as the app can’t proceed until these tasks are done.

TTFP will likely be slower, especially during app startup, because the app will be blocked while loading configuration from disk, meaning the UI won’t start rendering until all synchronous tasks are completed. This could lead to longer delays before the first visual elements are displayed on the screen.

👉 Assuming loading ~100 kB of JSON payload, my investigation leads me to show that there could be a delay of a few milliseconds on startup.

## Verification

Loaded augmented SDK against a test application to verify successful operation.

### ✔️ 15.5

<img width="1980" alt="Screenshot 2024-10-15 at 3 34 31 PM" src="https://github.com/user-attachments/assets/ea38fa17-ca93-4314-9049-bbac1a4fe883">

### ✔️ 16.0

<img width="1980" alt="Screenshot 2024-10-15 at 3 35 51 PM" src="https://github.com/user-attachments/assets/0268db44-3766-4c20-bc32-b37b324bd765">

### ✔️ 17.5

<img width="1980" alt="Screenshot 2024-10-15 at 3 38 11 PM" src="https://github.com/user-attachments/assets/35d040c8-d08f-4f94-9c2c-069bc401533a">

### ✔️ 18.0

<img width="1980" alt="Screenshot 2024-10-15 at 3 39 02 PM" src="https://github.com/user-attachments/assets/a8ecc41d-5012-4b08-be0e-abf3c185f720">

## Rollout

* Publish a fix to the next `patch` version.
* Backport fix to `3.2.0` branch.
* Notify customers who reported the bug.
* Notify others iOS customers on the `4.y.z` branch.