### PR TITLE
chore: move api to baseUrl

### DIFF
--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -1,6 +1,6 @@
 import Foundation;
 
-let UFC_CONFIG_URL = "/api/flag-config/v1/config"
+let UFC_CONFIG_URL = "/flag-config/v1/config"
 
 class ConfigurationRequester {
     private let httpClient: EppoHttpClient;

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -4,7 +4,7 @@ import Foundation;
 public let sdkName = "ios"
 public let sdkVersion = "3.3.1"
 
-public let defaultHost = "https://fscdn.eppo.cloud"
+public let defaultHost = "https://fscdn.eppo.cloud/api"
 
 public enum Errors: Error {
     case notConfigured


### PR DESCRIPTION
towards FF-3558
🎟️ [FF-3558](https://linear.app/eppo/issue/FF-3558/unify-sdk-request-baseurl)

## Motivation and Context
Most, nearly all in fact, of the SDKs use a baseUrl of https://fscdn.eppo.cloud/api and endpoint constants of `/flag-config/v1/config` and `/flag-config/v1/bandits` for flag and bandit requests.

All of the SDKs need to follow the common convention in order for our cross-SDK testing tools (scenario testing, benchmarking) to work seamlessly.

