### PR TITLE
renamed module to EppoFlagging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "eppo-flagging",
+    name: "EppoFlagging",
     platforms: [
         .iOS(.v13),
         .macOS(.v12)
@@ -12,8 +12,8 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "eppo-flagging",
-            targets: ["eppo-flagging"]),
+            name: "EppoFlagging",
+            targets: ["EppoFlagging"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -26,14 +26,14 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "eppo-flagging",
+            name: "EppoFlagging",
             dependencies: ["Semver"],
             path: "./Sources/eppo"
         ),
         .testTarget(
-            name: "eppo-flagging-tests",
+            name: "EppoFlaggingTests",
             dependencies: [
-                "eppo-flagging",
+                "EppoFlagging",
                 .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
             ],

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -2,7 +2,7 @@ import Foundation;
 
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "3.3.1"
+public let sdkVersion = "4.0.0"
 
 public let defaultHost = "https://fscdn.eppo.cloud"
 

--- a/Tests/eppo/AssignmentCacheTests.swift
+++ b/Tests/eppo/AssignmentCacheTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class AssignmentCacheTests: XCTestCase {
     var cache: InMemoryAssignmentCache!

--- a/Tests/eppo/AssignmentLoggerTests.swift
+++ b/Tests/eppo/AssignmentLoggerTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 
 final class AssignmentLoggerTests: XCTestCase {

--- a/Tests/eppo/AssignmentTests.swift
+++ b/Tests/eppo/AssignmentTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class AssignmentTests: XCTestCase {
     func testAssignmentInitialization() {

--- a/Tests/eppo/ClientAssignmentCacheTests.swift
+++ b/Tests/eppo/ClientAssignmentCacheTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class EppoClientAssignmentCachingTests: XCTestCase {
     var loggerSpy: AssignmentLoggerSpy!

--- a/Tests/eppo/ConfigurationRequesterTests.swift
+++ b/Tests/eppo/ConfigurationRequesterTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 class ConfigurationRequesterTests: XCTestCase {
     var httpClientMock: EppoHttpClientMock!

--- a/Tests/eppo/ConfigurationStoreTests.swift
+++ b/Tests/eppo/ConfigurationStoreTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class ConfigurationStoreTests: XCTestCase {
     var configurationStore: ConfigurationStore!

--- a/Tests/eppo/EppoClientDataTests.swift
+++ b/Tests/eppo/EppoClientDataTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 
 struct TestSubject : Decodable {

--- a/Tests/eppo/EppoValueTests.swift
+++ b/Tests/eppo/EppoValueTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 import Foundation
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 class EppoValueTests: XCTestCase {
 

--- a/Tests/eppo/ObfuscationTests.swift
+++ b/Tests/eppo/ObfuscationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 
 final class ObfuscationTests: XCTestCase {

--- a/Tests/eppo/OfflineClientTests.swift
+++ b/Tests/eppo/OfflineClientTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class OfflineClientTests: XCTestCase {
     var loggerSpy: AssignmentLoggerSpy!

--- a/Tests/eppo/RuleEvaluatorTests.swift
+++ b/Tests/eppo/RuleEvaluatorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class flagEvaluationTests: XCTestCase {
     public func testNoneResult() {

--- a/Tests/eppo/SharderTests.swift
+++ b/Tests/eppo/SharderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 class SharderTests: XCTestCase {
     

--- a/Tests/eppo/SharedTests.swift
+++ b/Tests/eppo/SharedTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 
 class AssignmentLoggerSpy {

--- a/Tests/eppo/SingletonTest.swift
+++ b/Tests/eppo/SingletonTest.swift
@@ -4,7 +4,7 @@ import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class EppoTests: XCTestCase {
     var stubCallCount = 0

--- a/Tests/eppo/UniversalFlagConfigTests.swift
+++ b/Tests/eppo/UniversalFlagConfigTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 import Foundation
 
-@testable import eppo_flagging
+@testable import EppoFlagging
 
 final class UniversalFlagConfigTest: XCTestCase {
     func testDecodeUFCConfig() {


### PR DESCRIPTION
## Observation

Conform to Swift conventions, for example https://github.com/airbnb/swift

Looked at some open source libraries for validation:

* https://github.com/nerdishbynature/octokit.swift/blob/main/Package.swift

👉 This is a good time to make these changes because we need to perform a breaking change to support a different behavior in the `baseURL`: https://github.com/Eppo-exp/eppo-ios-sdk/pull/49

Forward plan:

* Stack (https://github.com/Eppo-exp/eppo-ios-sdk/pull/49) on top of these changes to release in 4.0.0
* Update docs.geteppo.com (https://docs.geteppo.com/sdks/client-sdks/ios/) however there are no references to `eppo_flagging`