### PR TITLE
bug: add concurrency protection to AssignmentCache (FF-4172)

### DIFF
--- a/Sources/eppo/AssignmentCache.swift
+++ b/Sources/eppo/AssignmentCache.swift
@@ -13,7 +13,7 @@ public struct AssignmentCacheKey {
 }
 
 public class InMemoryAssignmentCache: AssignmentCache {
-    private let queue = DispatchQueue(label: "com.eppo.assignmentcache", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "cloud.eppo.assignmentcache", attributes: .concurrent)
     internal var cache: [CacheKey: CacheValue] = [:]
 
     internal struct CacheKey: Hashable {

--- a/Sources/eppo/Constants.swift
+++ b/Sources/eppo/Constants.swift
@@ -1,0 +1,5 @@
+// todo: make this a build argument (FF-1944)
+public let sdkName = "ios"
+public let sdkVersion = "4.0.1"
+
+public let defaultHost = "https://fscdn.eppo.cloud/api"

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,10 +1,5 @@
 import Foundation;
 
-// todo: make this a build argument (FF-1944)
-public let sdkName = "ios"
-public let sdkVersion = "4.0.0"
-
-public let defaultHost = "https://fscdn.eppo.cloud/api"
 
 public enum Errors: Error {
     case notConfigured

--- a/Tests/eppo/AssignmentCacheTests.swift
+++ b/Tests/eppo/AssignmentCacheTests.swift
@@ -77,4 +77,40 @@ final class AssignmentCacheTests: XCTestCase {
         XCTAssertFalse(cache.hasLoggedAssignment(key: key1))
         XCTAssertTrue(cache.hasLoggedAssignment(key: key2))
     }
+
+    func testConcurrentCacheAccess() async throws {
+        let iterations = 1000
+        let concurrentTasks = 10
+        
+        let key = AssignmentCacheKey(
+            subjectKey: "Math",
+            flagKey: "TestFlag",
+            allocationKey: "A1",
+            variationKey: "VariationA"
+        )
+        
+        await withTaskGroup(of: Void.self) { group in
+            // Add reader tasks
+            for _ in 0..<concurrentTasks {
+                group.addTask {
+                    for _ in 0..<iterations {
+                        _ = self.cache.hasLoggedAssignment(key: key)
+                    }
+                }
+            }
+            
+            // Add writer tasks
+            for _ in 0..<concurrentTasks {
+                group.addTask {
+                    for _ in 0..<iterations {
+                        self.cache.setLastLoggedAssignment(key: key)
+                    }
+                }
+            }
+        }
+        
+        // If we got here without crashing, the test passed
+        // The actual values don't matter as much as the fact that we didn't crash
+        // due to concurrent access
+    }
 }


### PR DESCRIPTION
## Observation

Customer report of crash https://github.com/Eppo-exp/eppo-ios-sdk/issues/52

## Description

Dictionary access in Swift is not thread-safe; the implementation of AssignmentCache has no protection against concurrent access.

* Adds `DispatchQueue` to guard access to the class
* Multiple consumers can check the cache status
* Only one thread can write at a time

## Test plan

**Wrote a test first to reproduce the issue**

<img width="2554" alt="Screenshot 2025-03-24 at 1 57 04 PM" src="https://github.com/user-attachments/assets/83aedd99-9a9e-4eda-baaa-2d8132e2f2dc" />

✔️  Implementation is passing the test

## Rollout plan

This PR is opened against `main` branch and we need to back port this change to the `3.x` branch and make a new release against it.