### PR TITLE
chore: DRY up namespace used for dispatch queue labels.

### DIFF
--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -9,7 +9,7 @@ class ConfigurationStore {
 
     private var configuration: Configuration?
     private let syncQueue = DispatchQueue(
-        label: "com.eppo.configurationStoreQueue", attributes: .concurrent)
+        label: "\(EPPO_NAMESPACE).configurationStoreQueue", attributes: .concurrent)
 
     private let cacheFileURL: URL?
     // This is a serial (non-concurrent) queue, so writers don't fight
@@ -18,7 +18,7 @@ class ConfigurationStore {
     // The queue is static because if there are multiple stores, they
     // would be sharing the cache file.
     static let persistenceQueue = DispatchQueue(
-      label: "com.eppo.configurationStorePersistence", qos: .background)
+      label: "\(EPPO_NAMESPACE).configurationStorePersistence", qos: .background)
     
     // Initialize with the disk-based path for storage
     public init(withPersistentCache: Bool = true) {

--- a/Sources/eppo/ConfigurationStore.swift
+++ b/Sources/eppo/ConfigurationStore.swift
@@ -9,7 +9,7 @@ class ConfigurationStore {
 
     private var configuration: Configuration?
     private let syncQueue = DispatchQueue(
-        label: "\(EPPO_NAMESPACE).configurationStoreQueue", attributes: .concurrent)
+        label: "cloud.eppo.configurationStoreQueue", attributes: .concurrent)
 
     private let cacheFileURL: URL?
     // This is a serial (non-concurrent) queue, so writers don't fight
@@ -18,7 +18,7 @@ class ConfigurationStore {
     // The queue is static because if there are multiple stores, they
     // would be sharing the cache file.
     static let persistenceQueue = DispatchQueue(
-      label: "\(EPPO_NAMESPACE).configurationStorePersistence", qos: .background)
+      label: "cloud.eppo.configurationStorePersistence", qos: .background)
     
     // Initialize with the disk-based path for storage
     public init(withPersistentCache: Bool = true) {

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,7 +1,7 @@
 import Foundation;
 
 // Public namespace for Eppo SDK
-public let EPPO_NAMESPACE = "cloud.eppo"
+package let eppoNamespace = "cloud.eppo"
 
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,8 +1,5 @@
 import Foundation;
 
-// Public namespace for Eppo SDK
-package let eppoNamespace = "cloud.eppo"
-
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
 public let sdkVersion = "4.0.0"
@@ -40,7 +37,7 @@ public class EppoClient {
     
     private static let sharedLock = NSLock()
     private static var sharedInstance: EppoClient?
-    private static let initializerQueue = DispatchQueue(label: "\(EPPO_NAMESPACE).client.initializer")
+    private static let initializerQueue = DispatchQueue(label: "cloud.eppo.client.initializer")
     
     private var flagEvaluator: FlagEvaluator = FlagEvaluator(sharder: MD5Sharder())
     

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -1,5 +1,8 @@
 import Foundation;
 
+// Public namespace for Eppo SDK
+public let EPPO_NAMESPACE = "cloud.eppo"
+
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
 public let sdkVersion = "4.0.0"
@@ -37,7 +40,7 @@ public class EppoClient {
     
     private static let sharedLock = NSLock()
     private static var sharedInstance: EppoClient?
-    private static let initializerQueue = DispatchQueue(label: "com.eppo.client.initializer")
+    private static let initializerQueue = DispatchQueue(label: "\(EPPO_NAMESPACE).client.initializer")
     
     private var flagEvaluator: FlagEvaluator = FlagEvaluator(sharder: MD5Sharder())
     


### PR DESCRIPTION
## motivation

* wrong company domain
* repeated string

## description

* DRY-up into a constant
* fix to `cloud.eppo` to reflect our domain