### PR TITLE
sdkName should use Constants.swift's sdkName, not literal "sdkName"

### DIFF
--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -60,7 +60,7 @@ public class EppoClient {
         let endpoints = ApiEndpoints(baseURL: host, sdkKey: self.sdkKey)
         self.host = endpoints.baseURL
 
-        let httpClient = NetworkEppoHttpClient(baseURL: self.host, sdkKey: self.sdkKey.token, sdkName: "sdkName", sdkVersion: sdkVersion)
+        let httpClient = NetworkEppoHttpClient(baseURL: self.host, sdkKey: self.sdkKey.token, sdkName: sdkName, sdkVersion: sdkVersion)
         self.configurationRequester = ConfigurationRequester(httpClient: httpClient)
 
         self.configurationStore = ConfigurationStore(withPersistentCache: withPersistentCache)


### PR DESCRIPTION
## Motivation and Context
I suspect you want to use the `sdkName` value from `Constants.swift` and not a literal `"sdkName"`

## Description
Use the `sdkName` from `Constants.swift`

## How has this been documented?
Not a public API change, no documentation

## How has this been tested?
I didn't test this.
