### PR TITLE
Use the given sdkName instead of literal "ios"

### DIFF
--- a/Sources/eppo/EppoHttpClient.swift
+++ b/Sources/eppo/EppoHttpClient.swift
@@ -34,8 +34,8 @@ public class NetworkEppoHttpClient: EppoHttpClient {
 
         // Set up the query items
         let queryItems = [
-            URLQueryItem(name: "sdkName", value: "ios"),
-            URLQueryItem(name: "sdkVersion", value: sdkVersion),
+            URLQueryItem(name: "sdkName", value: self.sdkName),
+            URLQueryItem(name: "sdkVersion", value: self.sdkVersion),
             // Server expects the existing response to continue to be `apiKey`.
             URLQueryItem(name: "apiKey", value: self.sdkKey)
         ]


### PR DESCRIPTION
## Motivation and Context
Consumers should be able to change the `sdkName` if they want a non-obfuscated response.

## Description
Previously the `sdkName` query parameter was always `"ios"`, but now it can be whatever a consumer passes.

## How has this been documented?
It wasn't documented before, so it still isn't

## How has this been tested?
I didn't test it.
