### PR TITLE
[FFL-485] always graceful mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ It is recommended to use the `load()` method to fetch the latest flag configurat
 Assignment is a synchronous operation.
 
 ```swift
-let assignment = try eppoClient.getStringAssignment(
+let assignment = eppoClient.getStringAssignment(
     flagKey: "new-user-onboarding",
     subjectKey: user.id,
     subjectAttributes: user.attributes,

--- a/Sources/eppo/Configuration.swift
+++ b/Sources/eppo/Configuration.swift
@@ -43,7 +43,7 @@ public struct Configuration: Codable {
             configFetchedAt: self.fetchedAt,
             configPublishedAt: self.publishedAt,
             configEnvironment: self.flagsConfiguration.environment,
-            configFormat: self.flagsConfiguration.format ?? "",
+            configFormat: self.flagsConfiguration.format,
             salt: nil
         )
     }

--- a/Sources/eppo/Constants.swift
+++ b/Sources/eppo/Constants.swift
@@ -1,5 +1,5 @@
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "4.4.0"
+public let sdkVersion = "5.0.0"
 
 public let defaultHost = "https://fscdn.eppo.cloud/api"

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -171,7 +171,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Bool) throws -> Bool {
+        defaultValue: Bool) -> Bool {
         do {
             return try getInternalAssignment(
                 flagKey: flagKey,
@@ -180,8 +180,6 @@ public class EppoClient {
                 expectedVariationType: UFC_VariationType.boolean
             )?.variation?.value.getBoolValue() ?? defaultValue
         } catch {
-            // TODO: In next major version, either properly throw errors or remove 'throws' keyword
-            // Currently masking errors for backward compatibility
             return defaultValue
         }
     }
@@ -190,7 +188,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes,
-        defaultValue: String) throws -> String {
+        defaultValue: String) -> String {
         do {
             return try getInternalAssignment(
                 flagKey: flagKey,
@@ -199,8 +197,6 @@ public class EppoClient {
                 expectedVariationType: UFC_VariationType.json
             )?.variation?.value.getStringValue() ?? defaultValue
         } catch {
-            // TODO: In next major version, either properly throw errors or remove 'throws' keyword
-            // Currently masking errors for backward compatibility
             return defaultValue
         }
     }
@@ -209,7 +205,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Int) throws -> Int {
+        defaultValue: Int) -> Int {
         do {
             let assignment = try getInternalAssignment(
                 flagKey: flagKey,
@@ -231,8 +227,6 @@ public class EppoClient {
             
             return Int(doubleValue)
         } catch {
-            // TODO: In next major version, either properly throw errors or remove 'throws' keyword
-            // Currently masking errors for backward compatibility
             return defaultValue
         }
     }
@@ -241,7 +235,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Double) throws -> Double {
+        defaultValue: Double) -> Double {
         do {
             return try getInternalAssignment(
                 flagKey: flagKey,
@@ -250,8 +244,6 @@ public class EppoClient {
                 expectedVariationType: UFC_VariationType.numeric
             )?.variation?.value.getDoubleValue() ?? defaultValue
         } catch {
-            // TODO: In next major version, either properly throw errors or remove 'throws' keyword
-            // Currently masking errors for backward compatibility
             return defaultValue
         }
     }
@@ -260,7 +252,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: String) throws -> String {
+        defaultValue: String) -> String {
         do {
             return try getInternalAssignment(
                 flagKey: flagKey,
@@ -269,8 +261,6 @@ public class EppoClient {
                 expectedVariationType: UFC_VariationType.string
             )?.variation?.value.getStringValue() ?? defaultValue
         } catch {
-            // TODO: In next major version, either properly throw errors or remove 'throws' keyword
-            // Currently masking errors for backward compatibility
             return defaultValue
         }
     }
@@ -467,7 +457,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: String) throws -> AssignmentDetails<String> {
+        defaultValue: String) -> AssignmentDetails<String> {
         do {
             let flagEvaluation = try getInternalAssignment(
                 flagKey: flagKey,
@@ -526,7 +516,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: String) throws -> AssignmentDetails<String> {
+        defaultValue: String) -> AssignmentDetails<String> {
         do {
             let flagEvaluation = try getInternalAssignment(
                 flagKey: flagKey,
@@ -595,7 +585,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Bool) throws -> AssignmentDetails<Bool> {
+        defaultValue: Bool) -> AssignmentDetails<Bool> {
         do {
             let flagEvaluation = try getInternalAssignment(
                 flagKey: flagKey,
@@ -654,7 +644,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Int) throws -> AssignmentDetails<Int> {
+        defaultValue: Int) -> AssignmentDetails<Int> {
         do {
             let flagEvaluation = try getInternalAssignment(
                 flagKey: flagKey,
@@ -762,7 +752,7 @@ public class EppoClient {
         flagKey: String,
         subjectKey: String,
         subjectAttributes: SubjectAttributes = SubjectAttributes(),
-        defaultValue: Double) throws -> AssignmentDetails<Double> {
+        defaultValue: Double) -> AssignmentDetails<Double> {
         do {
             let flagEvaluation = try getInternalAssignment(
                 flagKey: flagKey,

--- a/Tests/eppo/AssignmentLoggerTests.swift
+++ b/Tests/eppo/AssignmentLoggerTests.swift
@@ -36,9 +36,7 @@ final class AssignmentLoggerTests: XCTestCase {
    func testLogger() async throws {
        eppoClient = try await EppoClient.initialize(sdkKey: "mock-api-key", assignmentLogger: loggerSpy.logger, assignmentCache: nil)
 
-
-
-       let assignment = try eppoClient.getNumericAssignment(
+       let assignment = eppoClient.getNumericAssignment(
            flagKey: "numeric_flag",
            subjectKey: "6255e1a72a84e984aed55668",
            subjectAttributes: SubjectAttributes(),
@@ -214,7 +212,7 @@ final class AssignmentLoggerTests: XCTestCase {
            )
        )
 
-       let assignment = try eppoClient.getBooleanAssignment(
+       let assignment = eppoClient.getBooleanAssignment(
            flagKey: "boolean-flag",
            subjectKey: "test-subject-9",
            subjectAttributes: SubjectAttributes(),
@@ -379,7 +377,7 @@ final class AssignmentLoggerTests: XCTestCase {
            )
        )
 
-       let assignment = try eppoClient.getBooleanAssignment(
+       let assignment = eppoClient.getBooleanAssignment(
            flagKey: "boolean-flag",
            subjectKey: "test-subject-9",
            subjectAttributes: SubjectAttributes(),
@@ -464,7 +462,7 @@ final class AssignmentLoggerTests: XCTestCase {
            )
        )
 
-       let assignment = try eppoClient.getBooleanAssignment(
+       let assignment = eppoClient.getBooleanAssignment(
            flagKey: "boolean-flag",
            subjectKey: "test-subject-no-logging",
            subjectAttributes: SubjectAttributes(),

--- a/Tests/eppo/AssignmentLoggerTests.swift
+++ b/Tests/eppo/AssignmentLoggerTests.swift
@@ -212,7 +212,7 @@ final class AssignmentLoggerTests: XCTestCase {
            )
        )
 
-       let assignment = eppoClient.getBooleanAssignment(
+       let _ = eppoClient.getBooleanAssignment(
            flagKey: "boolean-flag",
            subjectKey: "test-subject-9",
            subjectAttributes: SubjectAttributes(),
@@ -377,7 +377,7 @@ final class AssignmentLoggerTests: XCTestCase {
            )
        )
 
-       let assignment = eppoClient.getBooleanAssignment(
+       let _ = eppoClient.getBooleanAssignment(
            flagKey: "boolean-flag",
            subjectKey: "test-subject-9",
            subjectAttributes: SubjectAttributes(),
@@ -462,7 +462,7 @@ final class AssignmentLoggerTests: XCTestCase {
            )
        )
 
-       let assignment = eppoClient.getBooleanAssignment(
+       let _ = eppoClient.getBooleanAssignment(
            flagKey: "boolean-flag",
            subjectKey: "test-subject-no-logging",
            subjectAttributes: SubjectAttributes(),

--- a/Tests/eppo/ClientAssignmentCacheTests.swift
+++ b/Tests/eppo/ClientAssignmentCacheTests.swift
@@ -37,13 +37,13 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
             assignmentCache: nil
         )
 
-        _ = try eppoClient.getNumericAssignment(
+        _ = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "6255e1a72a84e984aed55668",
             defaultValue: 0
         )
 
-        _ = try eppoClient.getNumericAssignment(
+        _ = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "6255e1a72a84e984aed55668",
             defaultValue: 0
@@ -64,12 +64,12 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
             assignmentLogger: loggerSpy.logger
         )
 
-        _ = try eppoClient.getNumericAssignment(
+        _ = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "6255e1a72a84e984aed55668",
             defaultValue: 0
         )
-        _ = try eppoClient.getNumericAssignment(
+        _ = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "6255e1a72a84e984aed55668",
             defaultValue: 0
@@ -90,12 +90,12 @@ final class EppoClientAssignmentCachingTests: XCTestCase {
             assignmentLogger: loggerSpy.logger
         )
 
-        _ =  try eppoClient.getStringAssignment(
+        _ = eppoClient.getStringAssignment(
             flagKey: "start-and-end-date-test",
             subjectKey: "6255e1a72a84e984aed55668",
             subjectAttributes: SubjectAttributes(),
             defaultValue: "")
-        _ = try eppoClient.getNumericAssignment(
+        _ = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "6255e1a72a84e984aed55668",
             defaultValue: 0

--- a/Tests/eppo/ConfigurationTests.swift
+++ b/Tests/eppo/ConfigurationTests.swift
@@ -87,7 +87,7 @@ final class ConfigurationTests: XCTestCase {
             initialConfiguration: configurationObject
         )
 
-        try XCTAssertEqual(newClient.getNumericAssignment(
+        XCTAssertEqual(newClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "test-subject",
             subjectAttributes: [:],
@@ -124,7 +124,7 @@ final class ConfigurationTests: XCTestCase {
             )
         )
         
-        try XCTAssertEqual(newClient.getNumericAssignment(
+        XCTAssertEqual(newClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "test-subject",
             subjectAttributes: [:],

--- a/Tests/eppo/EppoClientAssignmentDetailsTests.swift
+++ b/Tests/eppo/EppoClientAssignmentDetailsTests.swift
@@ -48,7 +48,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("US")
         ]
 
-        let result = try eppoClient.getIntegerAssignmentDetails(
+        let result = eppoClient.getIntegerAssignmentDetails(
             flagKey: "integer-flag",
             subjectKey: "alice",
             subjectAttributes: subjectAttributes,
@@ -114,7 +114,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("Brazil")
         ]
 
-        let result = try eppoClient.getIntegerAssignmentDetails(
+        let result = eppoClient.getIntegerAssignmentDetails(
             flagKey: "integer-flag",
             subjectKey: "alice",
             subjectAttributes: subjectAttributes,
@@ -161,7 +161,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("Brazil")
         ]
 
-        let result = try eppoClient.getStringAssignmentDetails(
+        let result = eppoClient.getStringAssignmentDetails(
             flagKey: "new-user-onboarding",
             subjectKey: "alice",
             subjectAttributes: subjectAttributes,
@@ -220,7 +220,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
     }
 
     func testUnrecognizedFlag() throws {
-        let result = try eppoClient.getIntegerAssignmentDetails(
+        let result = eppoClient.getIntegerAssignmentDetails(
             flagKey: "asdf",
             subjectKey: "alice",
             subjectAttributes: [:],
@@ -245,7 +245,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
     }
 
     func testTypeMismatch() throws {
-        let result = try eppoClient.getBooleanAssignmentDetails(
+        let result = eppoClient.getBooleanAssignmentDetails(
             flagKey: "integer-flag",
             subjectKey: "alice",
             subjectAttributes: [:],
@@ -275,7 +275,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("US")
         ]
 
-        let result = try eppoClient.getNumericAssignmentDetails(
+        let result = eppoClient.getNumericAssignmentDetails(
             flagKey: "numeric_flag",
             subjectKey: "alice",
             subjectAttributes: subjectAttributes,
@@ -297,7 +297,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("US")
         ]
 
-        let result = try eppoClient.getBooleanAssignmentDetails(
+        let result = eppoClient.getBooleanAssignmentDetails(
             flagKey: "kill-switch",
             subjectKey: "alice",
             subjectAttributes: subjectAttributes,
@@ -319,7 +319,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("US")
         ]
 
-        let result = try eppoClient.getJSONStringAssignmentDetails(
+        let result = eppoClient.getJSONStringAssignmentDetails(
             flagKey: "json-config-flag",
             subjectKey: "alice",
             subjectAttributes: subjectAttributes,
@@ -372,7 +372,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
             "country": EppoValue.valueOf("US")  // This will match the second allocation with the "pi" variation
         ]
 
-        let result = try eppoClient.getIntegerAssignmentDetails(
+        let result = eppoClient.getIntegerAssignmentDetails(
             flagKey: "invalid-value-flag",
             subjectKey: "test-subject",
             subjectAttributes: subjectAttributes,
@@ -400,7 +400,7 @@ final class EppoClientAssignmentDetailsTests: XCTestCase {
     }
 
     func testConfigPublishedAtTimestamp() throws {
-        let result = try eppoClient.getIntegerAssignmentDetails(
+        let result = eppoClient.getIntegerAssignmentDetails(
             flagKey: "integer-flag",
             subjectKey: "alice",
             subjectAttributes: [:],

--- a/Tests/eppo/EppoClientUFCTests.swift
+++ b/Tests/eppo/EppoClientUFCTests.swift
@@ -177,89 +177,57 @@ final class EppoClientUFCTests: XCTestCase {
                 // Get assignment details based on variation type
                 switch testCase.variationType {
                 case "BOOLEAN":
-                    do {
-                        let result = try eppoClient.getBooleanAssignmentDetails(
-                            flagKey: testCase.flag,
-                            subjectKey: subject.subjectKey,
-                            subjectAttributes: subjectAttributes,
-                            defaultValue: (testCase.defaultValue.value as? Bool) ?? false
-                        )
-                        XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
-                        verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
-                    } catch {
-                        throw error
-                    }
+                    let result = eppoClient.getBooleanAssignmentDetails(
+                        flagKey: testCase.flag,
+                        subjectKey: subject.subjectKey,
+                        subjectAttributes: subjectAttributes,
+                        defaultValue: (testCase.defaultValue.value as? Bool) ?? false
+                    )
+                    XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
+                    verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
                 case "NUMERIC":
-                    do {
-                        let result = try eppoClient.getNumericAssignmentDetails(
-                            flagKey: testCase.flag,
-                            subjectKey: subject.subjectKey,
-                            subjectAttributes: subjectAttributes,
-                            defaultValue: (testCase.defaultValue.value as? Double) ?? 0.0
-                        )
-                        XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
-                        verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
-                    } catch {
-                        throw error
-                    }
+                    let result = eppoClient.getNumericAssignmentDetails(
+                        flagKey: testCase.flag,
+                        subjectKey: subject.subjectKey,
+                        subjectAttributes: subjectAttributes,
+                        defaultValue: (testCase.defaultValue.value as? Double) ?? 0.0
+                    )
+                    XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
+                    verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
                 case "INTEGER":
-                    do {
-                        let result = try eppoClient.getIntegerAssignmentDetails(
-                            flagKey: testCase.flag,
-                            subjectKey: subject.subjectKey,
-                            subjectAttributes: subjectAttributes,
-                            defaultValue: (testCase.defaultValue.value as? Int) ?? 0
-                        )
-                        XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
-                        verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
-                    } catch {
-                        throw error
-                    }
+                    let result = eppoClient.getIntegerAssignmentDetails(
+                        flagKey: testCase.flag,
+                        subjectKey: subject.subjectKey,
+                        subjectAttributes: subjectAttributes,
+                        defaultValue: (testCase.defaultValue.value as? Int) ?? 0
+                    )
+                    XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
+                    verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
                 case "STRING":
-                    do {
-                        let result = try eppoClient.getStringAssignmentDetails(
-                            flagKey: testCase.flag,
-                            subjectKey: subject.subjectKey,
-                            subjectAttributes: subjectAttributes,
-                            defaultValue: (testCase.defaultValue.value as? String) ?? ""
-                        )
-                        XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
-                        verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
-                    } catch {
-                        throw error
-                    }
+                    let result = eppoClient.getStringAssignmentDetails(
+                        flagKey: testCase.flag,
+                        subjectKey: subject.subjectKey,
+                        subjectAttributes: subjectAttributes,
+                        defaultValue: (testCase.defaultValue.value as? String) ?? ""
+                    )
+                    XCTAssertEqual(result.variation, subject.assignment.value as? AnyHashable)
+                    verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
                 case "JSON":
-                    do {
-                        // If we expect a nil variation, pass nil as the default value
-                        let defaultValue: String? = (subject.assignment.value is NSNull || subject.evaluationDetails.flagEvaluationCode == "DEFAULT_ALLOCATION_NULL") ? nil : ""
-                        let result = try eppoClient.getJSONStringAssignmentDetails(
-                            flagKey: testCase.flag,
-                            subjectKey: subject.subjectKey,
-                            subjectAttributes: subjectAttributes,
-                            defaultValue: defaultValue ?? ""
-                        )
-                        // For JSON values, we need to handle nil variations
-                        if subject.assignment.value is NSNull || subject.evaluationDetails.flagEvaluationCode == "DEFAULT_ALLOCATION_NULL" {
-                            XCTAssertNil(result.variation)
-                        } else if let expectedDict = subject.assignment.value as? [String: Any] {
-                            // Convert dictionary to JSON string for comparison
-                            if let expectedData = try? JSONSerialization.data(withJSONObject: expectedDict, options: [.sortedKeys]),
-                               let expectedJSON = String(data: expectedData, encoding: .utf8) {
-                                // Normalize JSON strings for comparison
-                                func normalizeJSON(_ jsonString: String) -> String {
-                                    guard let data = jsonString.data(using: .utf8),
-                                          let json = try? JSONSerialization.jsonObject(with: data),
-                                          let normalizedData = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]) else {
-                                        return jsonString
-                                    }
-                                    return String(data: normalizedData, encoding: .utf8) ?? jsonString
-                                }
-                                XCTAssertNotNil(result.variation)
-                                XCTAssertEqual(normalizeJSON(result.variation!), normalizeJSON(expectedJSON))
-                            } else {
-                                XCTFail("Failed to convert expected dictionary to JSON")
-                            }
-                        } else if let expectedJSON = subject.assignment.value as? String {
+                    // If we expect a nil variation, pass nil as the default value
+                    let defaultValue: String? = (subject.assignment.value is NSNull || subject.evaluationDetails.flagEvaluationCode == "DEFAULT_ALLOCATION_NULL") ? nil : ""
+                    let result = eppoClient.getJSONStringAssignmentDetails(
+                        flagKey: testCase.flag,
+                        subjectKey: subject.subjectKey,
+                        subjectAttributes: subjectAttributes,
+                        defaultValue: defaultValue ?? ""
+                    )
+                    // For JSON values, we need to handle nil variations
+                    if subject.assignment.value is NSNull || subject.evaluationDetails.flagEvaluationCode == "DEFAULT_ALLOCATION_NULL" {
+                        XCTAssertNil(result.variation)
+                    } else if let expectedDict = subject.assignment.value as? [String: Any] {
+                        // Convert dictionary to JSON string for comparison
+                        if let expectedData = try? JSONSerialization.data(withJSONObject: expectedDict, options: [.sortedKeys]),
+                           let expectedJSON = String(data: expectedData, encoding: .utf8) {
                             // Normalize JSON strings for comparison
                             func normalizeJSON(_ jsonString: String) -> String {
                                 guard let data = jsonString.data(using: .utf8),
@@ -272,13 +240,25 @@ final class EppoClientUFCTests: XCTestCase {
                             XCTAssertNotNil(result.variation)
                             XCTAssertEqual(normalizeJSON(result.variation!), normalizeJSON(expectedJSON))
                         } else {
-                            XCTAssertNotNil(result.variation)
-                            XCTAssertEqual(result.variation!, subject.assignment.value as? AnyHashable)
+                            XCTFail("Failed to convert expected dictionary to JSON")
                         }
-                        verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
-                    } catch {
-                        throw error
+                    } else if let expectedJSON = subject.assignment.value as? String {
+                        // Normalize JSON strings for comparison
+                        func normalizeJSON(_ jsonString: String) -> String {
+                            guard let data = jsonString.data(using: .utf8),
+                                  let json = try? JSONSerialization.jsonObject(with: data),
+                                  let normalizedData = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]) else {
+                                return jsonString
+                            }
+                            return String(data: normalizedData, encoding: .utf8) ?? jsonString
+                        }
+                        XCTAssertNotNil(result.variation)
+                        XCTAssertEqual(normalizeJSON(result.variation!), normalizeJSON(expectedJSON))
+                    } else {
+                        XCTAssertNotNil(result.variation)
+                        XCTAssertEqual(result.variation!, subject.assignment.value as? AnyHashable)
                     }
+                    verifyEvaluationDetails(result.evaluationDetails, subject.evaluationDetails)
                 default:
                     XCTFail("Unknown variation type: \(testCase.variationType)")
                     continue

--- a/Tests/eppo/OfflineClientTests.swift
+++ b/Tests/eppo/OfflineClientTests.swift
@@ -59,7 +59,7 @@ final class OfflineClientTests: XCTestCase {
         )
 
         // Perform an assignment with the initial client
-        let initialAssignment = try eppoClient.getNumericAssignment(
+        let initialAssignment = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "alice",
             defaultValue: 100
@@ -118,7 +118,7 @@ final class OfflineClientTests: XCTestCase {
         try await eppoClient.load()
 
         // Perform a different assignment with the updated client
-        let updatedAssignment = try eppoClient.getNumericAssignment(
+        let updatedAssignment = eppoClient.getNumericAssignment(
             flagKey: "numeric_flag",
             subjectKey: "alice",
             defaultValue: 100


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

The iOS SDK had a design issue where assignment methods were marked as throws but never actually threw errors to the caller. Instead, they internally caught all errors and returned default values. This created a confusing API that violated Swift's design principles - methods should either be throwable and actually throw errors, or not be throwable at all.

In the future, we could add always-non-graceful methods (name ideas: `get*AssignmentNonGraceful` or `get*AssignmentDangerously`) but for the existing functions I am inclined to be consistent with the rest of our SDKs where the modus operandi is not throw errors.

## Description
[//]: # (Describe your changes in detail)

* Removed throws keyword from all assignment methods:
  * `getBooleanAssignment`
  * `getJSONStringAssignment`
  * `getIntegerAssignment`
  * `getNumericAssignment`
  * `getStringAssignment`
  * `getStringAssignmentDetails`
  * `getJSONStringAssignmentDetails`
  * `getBooleanAssignmentDetails`
  * `getIntegerAssignmentDetails`
  * `getNumericAssignmentDetails`
* Updated test files to remove unnecessary try keywords from assignment method calls across all test files
* Fixed compiler warnings by removing unused variable assignments and unnecessary nil coalescing operators
* Bumped SDK version from 4.4.0 to 5.0.0 to reflect the breaking API changes

This change makes the API more honest and easier to use - callers no longer need to use try-catch blocks for methods that never throw errors.

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

This is a breaking change that requires updating the SDK version to 5.0.0. The documentation needs to be updated to reflect that assignment methods no longer throw errors. https://github.com/Eppo-exp/eppo-docs/pull/692

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

* Updated all test files to remove try keywords from assignment method calls
* Verified compilation - all tests compile and run successfully with the new API