### PR TITLE
[FFL-769] config change callback

### DIFF
--- a/Sources/eppo/Constants.swift
+++ b/Sources/eppo/Constants.swift
@@ -1,5 +1,5 @@
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "5.1.0"
+public let sdkVersion = "5.2.0"
 
 public let defaultHost = "https://fscdn.eppo.cloud/api"

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -14,6 +14,7 @@ public enum Errors: Error {
 }
 
 public typealias SubjectAttributes = [String: EppoValue]
+public typealias ConfigurationChangeCallback = (Configuration) -> Void
 actor EppoClientState {
     private(set) var isLoaded: Bool = false
 
@@ -42,6 +43,7 @@ public class EppoClient {
     private(set) var configurationStore: ConfigurationStore
     private var configurationRequester: ConfigurationRequester
     private var poller: Poller?
+    private var configurationChangeCallback: ConfigurationChangeCallback?
 
     private let state = EppoClientState()
 
@@ -66,6 +68,7 @@ public class EppoClient {
         self.configurationStore = ConfigurationStore(withPersistentCache: withPersistentCache)
         if let configuration = initialConfiguration {
             self.configurationStore.setConfiguration(configuration: configuration)
+            // Note: Callbacks will be registered after init, so initial config callback will be triggered during loadIfNeeded
         }
     }
 
@@ -78,7 +81,8 @@ public class EppoClient {
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         initialConfiguration: Configuration?,
-        withPersistentCache: Bool = true
+        withPersistentCache: Bool = true,
+        configurationChangeCallback: ConfigurationChangeCallback? = nil
     ) -> EppoClient {
         return sharedLock.withLock {
             if let instance = sharedInstance {
@@ -92,6 +96,11 @@ public class EppoClient {
                   initialConfiguration: initialConfiguration,
                   withPersistentCache: withPersistentCache
                 )
+                
+                if let callback = configurationChangeCallback {
+                    instance.onConfigurationChange(callback)
+                }
+                
                 sharedInstance = instance
                 return instance
             }
@@ -106,7 +115,8 @@ public class EppoClient {
         initialConfiguration: Configuration? = nil,
         pollingEnabled: Bool = false,
         pollingIntervalMs: Int = PollerConstants.DEFAULT_POLL_INTERVAL_MS,
-        pollingJitterMs: Int = PollerConstants.DEFAULT_POLL_INTERVAL_MS / PollerConstants.DEFAULT_JITTER_INTERVAL_RATIO
+        pollingJitterMs: Int = PollerConstants.DEFAULT_POLL_INTERVAL_MS / PollerConstants.DEFAULT_JITTER_INTERVAL_RATIO,
+        configurationChangeCallback: ConfigurationChangeCallback? = nil
     ) async throws -> EppoClient {
         let instance = Self.initializeOffline(
             sdkKey: sdkKey,
@@ -115,6 +125,10 @@ public class EppoClient {
             assignmentCache: assignmentCache,
             initialConfiguration: initialConfiguration
         )
+        
+        if let callback = configurationChangeCallback {
+            instance.onConfigurationChange(callback)
+        }
 
         return try await withCheckedThrowingContinuation { continuation in
             initializerQueue.async {
@@ -152,6 +166,7 @@ public class EppoClient {
     public func load() async throws {
         let config = try await self.configurationRequester.fetchConfigurations()
         self.configurationStore.setConfiguration(configuration: config)
+        notifyConfigurationChange(config)
     }
 
     public static func resetSharedInstance() {
@@ -162,7 +177,13 @@ public class EppoClient {
 
     private func loadIfNeeded() async throws {
         let alreadyLoaded = await state.checkAndSetLoaded()
-        guard !alreadyLoaded else { return }
+        guard !alreadyLoaded else { 
+            // If already loaded but we have an existing configuration, notify callbacks
+            if let existingConfig = configurationStore.getConfiguration() {
+                notifyConfigurationChange(existingConfig)
+            }
+            return 
+        }
 
         try await self.load()
     }
@@ -832,6 +853,16 @@ public class EppoClient {
     public func stopPolling() {
         poller?.stop()
         poller = nil
+    }
+    
+    /// Registers a callback for when a new configuration is applied to the EppoClient instance.
+    public func onConfigurationChange(_ callback: @escaping ConfigurationChangeCallback) {
+        configurationChangeCallback = callback
+    }
+    
+    /// Notifies the registered callback when configuration changes.
+    private func notifyConfigurationChange(_ configuration: Configuration) {
+        configurationChangeCallback?(configuration)
     }
 }
 

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -123,12 +123,9 @@ public class EppoClient {
             host: host,
             assignmentLogger: assignmentLogger,
             assignmentCache: assignmentCache,
-            initialConfiguration: initialConfiguration
+            initialConfiguration: initialConfiguration,
+            configurationChangeCallback: configurationChangeCallback
         )
-        
-        if let callback = configurationChangeCallback {
-            instance.onConfigurationChange(callback)
-        }
 
         return try await withCheckedThrowingContinuation { continuation in
             initializerQueue.async {

--- a/Tests/eppo/ConfigurationChangeCallbackTests.swift
+++ b/Tests/eppo/ConfigurationChangeCallbackTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable import EppoFlagging
+
+final class ConfigurationChangeCallbackTests: XCTestCase {
+    let DUMMY_SDK_KEY = "dummy_sdk_key"
+    
+    override func setUp() {
+        super.setUp()
+        EppoClient.resetSharedInstance()
+        HTTPStubs.removeAllStubs()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        HTTPStubs.removeAllStubs()
+        EppoClient.resetSharedInstance()
+    }
+    
+    func testConfigurationChangeListenerBuilderInitialization() async throws {
+        var receivedConfigurations: [Configuration] = []
+        
+        // Stub the HTTP requests to return empty config first, then a config with a flag
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            // First call returns empty config
+            let emptyConfig = """
+            {
+              "format": "SERVER",
+              "createdAt": "2024-04-17T19:40:53.716Z",
+              "environment": {"name": "Test"},
+              "flags": {}
+            }
+            """.data(using: .utf8)!
+            
+            return HTTPStubsResponse(data: emptyConfig, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Initialize client with configuration change callback in builder
+        let eppoClient = try await EppoClient.initialize(
+            sdkKey: DUMMY_SDK_KEY,
+            configurationChangeCallback: { config in
+                receivedConfigurations.append(config)
+            }
+        )
+        
+        // Verify initial callback was triggered
+        XCTAssertEqual(receivedConfigurations.count, 1)
+        
+        // Now stub a different config response
+        HTTPStubs.removeAllStubs()
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let boolFlagConfig = """
+            {
+              "format": "SERVER",
+              "createdAt": "2024-04-17T19:40:53.716Z",
+              "environment": {"name": "Test"},
+              "flags": {
+                "bool_flag": {
+                  "key": "bool_flag",
+                  "enabled": true,
+                  "variationType": "BOOLEAN",
+                  "variations": {
+                    "true": {"key": "true", "value": {"boolValue": true}},
+                    "false": {"key": "false", "value": {"boolValue": false}}
+                  },
+                  "allocations": [{
+                    "key": "allocation1",
+                    "rules": [],
+                    "splits": [{"variationKey": "true", "shards": [{"salt": "salt", "ranges": [{"start": 0, "end": 10000}]}]}],
+                    "doLog": true
+                  }],
+                  "totalShards": 10000
+                }
+              }
+            }
+            """.data(using: .utf8)!
+            
+            return HTTPStubsResponse(data: boolFlagConfig, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Trigger a manual reload
+        try await eppoClient.load()
+        
+        // Verify callback was triggered again
+        XCTAssertEqual(receivedConfigurations.count, 2)
+        
+        // Reload again - callback should be triggered even if config is the same
+        try await eppoClient.load()
+        
+        // Verify callback was triggered a third time
+        XCTAssertEqual(receivedConfigurations.count, 3)
+    }
+    
+    func testConfigurationChangeListenerSetAfterInitialization() async throws {
+        var configurationChangedCount = 0
+        let expectation = self.expectation(description: "Configuration change callback")
+        expectation.expectedFulfillmentCount = 2 // Initial load + one poll
+        
+        // Stub HTTP requests
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let emptyConfig = """
+            {
+              "format": "SERVER",
+              "createdAt": "2024-04-17T19:40:53.716Z",
+              "environment": {"name": "Test"},
+              "flags": {}
+            }
+            """.data(using: .utf8)!
+            
+            return HTTPStubsResponse(data: emptyConfig, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Initialize client with polling enabled (short interval for test)
+        let eppoClient = try await EppoClient.initialize(
+            sdkKey: DUMMY_SDK_KEY,
+            pollingEnabled: true,
+            pollingIntervalMs: 100, // 100ms for quick test
+            pollingJitterMs: 0
+        )
+        
+        // Set callback after initialization
+        eppoClient.onConfigurationChange { _ in
+            configurationChangedCount += 1
+            expectation.fulfill()
+        }
+        
+        // Wait for initial config and at least one polling cycle
+        await fulfillment(of: [expectation], timeout: 5.0)
+        
+        // Should have been called at least twice (initial + polling)
+        XCTAssertGreaterThanOrEqual(configurationChangedCount, 2)
+        
+        // Stop polling to clean up
+        await eppoClient.stopPolling()
+    }
+    
+    func testConfigurationChangeListenerOverwrite() async throws {
+        var firstCallbackCount = 0
+        var secondCallbackCount = 0
+        
+        // Stub HTTP requests
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let emptyConfig = """
+            {
+              "format": "SERVER",
+              "createdAt": "2024-04-17T19:40:53.716Z",
+              "environment": {"name": "Test"},
+              "flags": {}
+            }
+            """.data(using: .utf8)!
+            
+            return HTTPStubsResponse(data: emptyConfig, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Initialize client with first callback
+        let eppoClient = try await EppoClient.initialize(
+            sdkKey: DUMMY_SDK_KEY,
+            configurationChangeCallback: { _ in
+                firstCallbackCount += 1
+            }
+        )
+        
+        // First callback should have been called during initialization
+        XCTAssertEqual(firstCallbackCount, 1)
+        XCTAssertEqual(secondCallbackCount, 0)
+        
+        // Replace with second callback
+        eppoClient.onConfigurationChange { _ in
+            secondCallbackCount += 1
+        }
+        
+        // Trigger another load
+        try await eppoClient.load()
+        
+        // Only second callback should be called, first should be overwritten
+        XCTAssertEqual(firstCallbackCount, 1) // No change
+        XCTAssertEqual(secondCallbackCount, 1) // Called once
+    }
+    
+    func testConfigurationChangeListenerOfflineInitialization() {
+        var receivedConfigurations: [Configuration] = []
+        
+        // Create a mock initial configuration
+        let initialConfigData = """
+        {
+          "format": "SERVER",
+          "createdAt": "2024-04-17T19:40:53.716Z",
+          "environment": {"name": "Test"},
+          "flags": {}
+        }
+        """.data(using: .utf8)!
+        
+        let initialConfig = try! Configuration(flagsConfigurationJson: initialConfigData, obfuscated: false)
+        
+        // Initialize offline client with callback and initial configuration
+        let eppoClient = EppoClient.initializeOffline(
+            sdkKey: DUMMY_SDK_KEY,
+            initialConfiguration: initialConfig,
+            configurationChangeCallback: { config in
+                receivedConfigurations.append(config)
+            }
+        )
+        
+        // Configuration change callback should not be triggered for offline initialization
+        // until load is called (similar to Android behavior)
+        XCTAssertEqual(receivedConfigurations.count, 0)
+        
+        // Verify the client has the initial configuration
+        let storedConfig = eppoClient.getFlagsConfiguration()
+        XCTAssertNotNil(storedConfig)
+    }
+}


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes [FFL-769](https://datadoghq.atlassian.net/browse/FFL-769)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

To catch up with the Android SDK
* https://github.com/Eppo-exp/android-sdk/pull/167
* https://github.com/Eppo-exp/sdk-common-jdk/pull/97

## Description
[//]: # (Describe your changes in detail)

I had two options:

Option 1: Match Common SDK (More Complex)
- Support multiple callbacks
- Add unsubscription mechanism
- Add thread safety

Option 2: Match Android SDK (Simpler API)
- Single callback (simpler for most use cases)
- No unsubscription complexity
- Swift-style optional callback

| Feature in Common | Android SDK | iOS SDK |
|---|---|---|
| Builder callback registration   | ✅ .onConfigurationChange(callback)       | ✅ configurationChangeCallback: callback  |
| Post-init callback registration | ✅ client.onConfigurationChange(callback) | ✅ client.onConfigurationChange(callback) |
| Single callback storage | ✅ Overwrites previous callback | ✅ Overwrites previous callback |
| Multiple callbacks | ❌ Not exposed publicly | ❌ Not implemented |
| Unsubscription | ❌ Not exposed publicly | ❌ Not implemented |
| Callback triggering | ✅ On load/reload/polling | ✅ On load/reload/polling 

Decision: The Android approach (with a single callback) is probably sufficient for an initial release, and we can consider adding multiple callback support as a future enhancement.

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
