### PR TITLE
Sameeran/fflnew 881

### DIFF
--- a/DebugExample.swift
+++ b/DebugExample.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+// Example usage of the new debug callback feature with timing context
+
+// Simple print example with timing in milliseconds
+let simplePrintCallback: (String, Double, Double) -> Void = { message, elapsedTimeMs, stepDurationMs in
+    print("[\(String(format: "%.1f", elapsedTimeMs))ms] \(message) (step: \(String(format: "%.1f", stepDurationMs))ms)")
+}
+
+// DataDog example with custom attributes (pseudocode)
+let dataDogCallback: (String, Double, Double) -> Void = { message, elapsedTimeMs, stepDurationMs in
+    // Assuming DataDog SDK is available
+    // RUMMonitor.shared().addAction(
+    //     type: .custom,
+    //     name: "eppo_initialization_step",
+    //     attributes: [
+    //         "message": message,
+    //         "step_duration_ms": stepDurationMs,
+    //         "elapsed_time_ms": elapsedTimeMs
+    //     ]
+    // )
+}
+
+// Usage examples:
+
+// With simple print debugging
+func initializeWithSimplePrint() async throws {
+    let eppoClient = try await EppoClient.initialize(
+        sdkKey: "your-sdk-key",
+        debugCallback: simplePrintCallback
+    )
+}
+
+// With DataDog integration
+func initializeWithDataDog() async throws {
+    let eppoClient = try await EppoClient.initialize(
+        sdkKey: "your-sdk-key", 
+        debugCallback: dataDogCallback
+    )
+}
+
+// Without debugging (production)
+func initializeProduction() async throws {
+    let eppoClient = try await EppoClient.initialize(
+        sdkKey: "your-sdk-key"
+        // No debugCallback parameter = no debugging overhead
+    )
+}
+
+// Custom timing analysis example - much cleaner with automatic timing!
+func initializeWithCustomTiming() async throws {
+    let customCallback: (String, Double, Double) -> Void = { message, elapsedTimeMs, stepDurationMs in
+        if stepDurationMs == 0.0 {
+            print("🚀 Init started: \(message)")
+        } else {
+            print("⏱️  [\(String(format: "%.1f", elapsedTimeMs))ms total] Step took \(String(format: "%.1f", stepDurationMs))ms: \(message)")
+        }
+        
+        if message.contains("Total SDK initialization completed") {
+            print("🎉 Initialization complete in \(String(format: "%.1f", elapsedTimeMs))ms!")
+        }
+    }
+    
+    let eppoClient = try await EppoClient.initialize(
+        sdkKey: "your-sdk-key",
+        debugCallback: customCallback
+    )
+}

--- a/Sources/eppo/ConfigurationRequester.swift
+++ b/Sources/eppo/ConfigurationRequester.swift
@@ -4,13 +4,44 @@ let UFC_CONFIG_URL = "/flag-config/v1/config"
 
 class ConfigurationRequester {
     private let httpClient: EppoHttpClient
+    private var debugLogger: ((String) -> Void)?
 
     public init(httpClient: EppoHttpClient) {
         self.httpClient = httpClient
+        self.debugLogger = nil
+    }
+    
+    public func setDebugLogger(_ logger: @escaping (String) -> Void) {
+        self.debugLogger = logger
     }
 
     public func fetchConfigurations() async throws -> Configuration {
-        let (data, _) = try await httpClient.get(UFC_CONFIG_URL)
-        return try Configuration(flagsConfigurationJson: data, obfuscated: true)
+        let networkStartTime = Date()
+        debugLogger?("Starting network request to fetch configuration")
+        
+        let (data, response) = try await httpClient.get(UFC_CONFIG_URL)
+        
+        let networkCompleteTime = Date()
+        let networkDuration = networkCompleteTime.timeIntervalSince(networkStartTime)
+        
+        // Log response details
+        if let httpResponse = response as? HTTPURLResponse {
+            debugLogger?("Network request completed in \(String(format: "%.3f", networkDuration)) seconds (Status: \(httpResponse.statusCode), Data size: \(data.count) bytes)")
+        } else {
+            debugLogger?("Network request completed in \(String(format: "%.3f", networkDuration)) seconds (Data size: \(data.count) bytes)")
+        }
+        
+        let parseStartTime = Date()
+        debugLogger?("Starting JSON parsing and configuration creation")
+        
+        let configuration = try Configuration(flagsConfigurationJson: data, obfuscated: true)
+        
+        let parseDuration = Date().timeIntervalSince(parseStartTime)
+        debugLogger?("JSON parsing and configuration creation completed in \(String(format: "%.3f", parseDuration)) seconds")
+        
+        let totalFetchTime = Date().timeIntervalSince(networkStartTime)
+        debugLogger?("Total fetchConfigurations completed in \(String(format: "%.3f", totalFetchTime)) seconds")
+        
+        return configuration
     }
 }

--- a/Sources/eppo/EppoClient.swift
+++ b/Sources/eppo/EppoClient.swift
@@ -46,6 +46,9 @@ public class EppoClient {
     private var configurationChangeCallback: ConfigurationChangeCallback?
 
     private let state = EppoClientState()
+    private let debugCallback: ((String, Double, Double) -> Void)?
+    private var debugInitStartTime: Date?
+    private var debugLastStepTime: Date?
 
     private init(
         sdkKey: String,
@@ -53,11 +56,15 @@ public class EppoClient {
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         initialConfiguration: Configuration?,
-        withPersistentCache: Bool = true
+        withPersistentCache: Bool = true,
+        debugCallback: ((String, Double, Double) -> Void)? = nil
     ) {
         self.sdkKey = SDKKey(sdkKey)
         self.assignmentLogger = assignmentLogger
         self.assignmentCache = assignmentCache
+        self.debugCallback = debugCallback
+        self.debugInitStartTime = nil
+        self.debugLastStepTime = nil
 
         let endpoints = ApiEndpoints(baseURL: host, sdkKey: self.sdkKey)
         self.host = endpoints.baseURL
@@ -69,6 +76,13 @@ public class EppoClient {
         if let configuration = initialConfiguration {
             self.configurationStore.setConfiguration(configuration: configuration)
             // Note: Callbacks will be registered after init, so initial config callback will be triggered during loadIfNeeded
+        }
+        
+        // Set up debug logging for ConfigurationRequester after all properties are initialized
+        if debugCallback != nil {
+            self.configurationRequester.setDebugLogger { [weak self] message in
+                self?.debugLog(message)
+            }
         }
     }
 
@@ -82,7 +96,8 @@ public class EppoClient {
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         initialConfiguration: Configuration?,
         withPersistentCache: Bool = true,
-        configurationChangeCallback: ConfigurationChangeCallback? = nil
+        configurationChangeCallback: ConfigurationChangeCallback? = nil,
+        debugCallback: ((String, Double, Double) -> Void)? = nil
     ) -> EppoClient {
         return sharedLock.withLock {
             if let instance = sharedInstance {
@@ -94,7 +109,8 @@ public class EppoClient {
                   assignmentLogger: assignmentLogger,
                   assignmentCache: assignmentCache,
                   initialConfiguration: initialConfiguration,
-                  withPersistentCache: withPersistentCache
+                  withPersistentCache: withPersistentCache,
+                  debugCallback: debugCallback
                 )
                 
                 if let callback = configurationChangeCallback {
@@ -116,7 +132,8 @@ public class EppoClient {
         pollingEnabled: Bool = false,
         pollingIntervalMs: Int = PollerConstants.DEFAULT_POLL_INTERVAL_MS,
         pollingJitterMs: Int = PollerConstants.DEFAULT_POLL_INTERVAL_MS / PollerConstants.DEFAULT_JITTER_INTERVAL_RATIO,
-        configurationChangeCallback: ConfigurationChangeCallback? = nil
+        configurationChangeCallback: ConfigurationChangeCallback? = nil,
+        debugCallback: ((String, Double, Double) -> Void)? = nil
     ) async throws -> EppoClient {
         let instance = Self.initializeOffline(
             sdkKey: sdkKey,
@@ -124,22 +141,42 @@ public class EppoClient {
             assignmentLogger: assignmentLogger,
             assignmentCache: assignmentCache,
             initialConfiguration: initialConfiguration,
-            configurationChangeCallback: configurationChangeCallback
+            configurationChangeCallback: configurationChangeCallback,
+            debugCallback: debugCallback
         )
 
         return try await withCheckedThrowingContinuation { continuation in
             initializerQueue.async {
                 Task {
                     do {
+                        let initStartTime = Date()
+                        instance.debugLog("Starting Eppo SDK initialization")
+                        
                         try await instance.loadIfNeeded()
+                        
+                        let loadCompleteTime = Date()
+                        let loadDuration = loadCompleteTime.timeIntervalSince(initStartTime)
+                        instance.debugLog("Configuration loading completed in \(String(format: "%.3f", loadDuration)) seconds")
+                        
                         if pollingEnabled {
+                            let pollingStartTime = Date()
+                            instance.debugLog("Starting polling setup")
+                            
                             try await instance.startPolling(
                                 intervalMs: pollingIntervalMs,
                                 jitterMs: pollingJitterMs
                             )
+                            
+                            let pollingSetupTime = Date().timeIntervalSince(pollingStartTime)
+                            instance.debugLog("Polling setup completed in \(String(format: "%.3f", pollingSetupTime)) seconds")
                         }
+                        
+                        let totalInitTime = Date().timeIntervalSince(initStartTime)
+                        instance.debugLog("Total SDK initialization completed in \(String(format: "%.3f", totalInitTime)) seconds")
+                        
                         continuation.resume(returning: instance)
                     } catch {
+                        instance.debugLog("SDK initialization failed with error: \(error.localizedDescription)")
                         continuation.resume(throwing: error)
                     }
                 }
@@ -161,9 +198,27 @@ public class EppoClient {
     // This function can be called from multiple threads; synchronization is provided to safely update
     // the configuration cache but each invocation will execute a new network request with billing impact.
     public func load() async throws {
+        let fetchStartTime = Date()
+        debugLog("Starting configuration fetch from remote")
+        
         let config = try await self.configurationRequester.fetchConfigurations()
+        
+        let fetchCompleteTime = Date()
+        let fetchDuration = fetchCompleteTime.timeIntervalSince(fetchStartTime)
+        debugLog("Configuration fetch and parsing completed in \(String(format: "%.3f", fetchDuration)) seconds")
+        
+        let storeStartTime = Date()
+        debugLog("Starting configuration storage")
+        
         self.configurationStore.setConfiguration(configuration: config)
+        
+        let storeDuration = Date().timeIntervalSince(storeStartTime)
+        debugLog("Configuration storage completed in \(String(format: "%.3f", storeDuration)) seconds")
+        
         notifyConfigurationChange(config)
+        
+        let totalLoadTime = Date().timeIntervalSince(fetchStartTime)
+        debugLog("Total configuration load completed in \(String(format: "%.3f", totalLoadTime)) seconds")
     }
 
     public static func resetSharedInstance() {
@@ -175,6 +230,7 @@ public class EppoClient {
     private func loadIfNeeded() async throws {
         let alreadyLoaded = await state.checkAndSetLoaded()
         guard !alreadyLoaded else { 
+            debugLog("SDK already loaded, using cached configuration")
             // If already loaded but we have an existing configuration, notify callbacks
             if let existingConfig = configurationStore.getConfiguration() {
                 notifyConfigurationChange(existingConfig)
@@ -182,6 +238,7 @@ public class EppoClient {
             return 
         }
 
+        debugLog("First-time initialization detected, loading configuration")
         try await self.load()
     }
 
@@ -861,6 +918,29 @@ public class EppoClient {
     private func notifyConfigurationChange(_ configuration: Configuration) {
         configurationChangeCallback?(configuration)
     }
+    
+    /// Internal debug logging with timing context
+    private func debugLog(_ message: String) {
+        guard let callback = debugCallback else { return }
+        
+        let now = Date()
+        
+        // Initialize timing on first call
+        if debugInitStartTime == nil {
+            debugInitStartTime = now
+            debugLastStepTime = now
+            callback(message, 0.0, 0.0)
+            return
+        }
+        
+        // Calculate elapsed and step times in milliseconds
+        let elapsedTimeMs = now.timeIntervalSince(debugInitStartTime!) * 1000.0
+        let stepDurationMs = debugLastStepTime != nil ? now.timeIntervalSince(debugLastStepTime!) * 1000.0 : 0.0
+        
+        debugLastStepTime = now
+        callback(message, elapsedTimeMs, stepDurationMs)
+    }
+    
 }
 
 func isValueOfType(expectedType: UFC_VariationType, variationValue: EppoValue) -> Bool {

--- a/Tests/eppo/DebugCallbackTests.swift
+++ b/Tests/eppo/DebugCallbackTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+
+@testable import EppoFlagging
+
+final class DebugCallbackTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Reset shared instance before each test
+        EppoClient.resetSharedInstance()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        HTTPStubs.removeAllStubs()
+        EppoClient.resetSharedInstance()
+    }
+    
+    func testDebugCallbackReceivesTimingData() async throws {
+        // Arrange
+        var capturedMessages: [(String, Double, Double)] = []
+        let debugCallback: (String, Double, Double) -> Void = { message, elapsedMs, stepMs in
+            capturedMessages.append((message, elapsedMs, stepMs))
+        }
+        
+        // Mock the HTTP response for configuration fetch
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let testConfig = """
+            {
+                "flags": {},
+                "createdAt": "2023-01-01T00:00:00.000Z",
+                "environment": {"name": "test"},
+                "format": "SERVER_1_0"
+            }
+            """
+            return HTTPStubsResponse(data: testConfig.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Act
+        let _ = try await EppoClient.initialize(
+            sdkKey: "test-sdk-key",
+            debugCallback: debugCallback
+        )
+        
+        // Assert
+        XCTAssertGreaterThan(capturedMessages.count, 0, "Debug callback should receive messages")
+        
+        // Verify first message has zero elapsed time and step duration
+        let firstMessage = capturedMessages.first!
+        XCTAssertTrue(firstMessage.0.contains("Starting Eppo SDK initialization"))
+        XCTAssertEqual(firstMessage.1, 0.0, "First message should have 0ms elapsed time")
+        XCTAssertEqual(firstMessage.2, 0.0, "First message should have 0ms step duration")
+        
+        // Verify subsequent messages have positive timing values
+        if capturedMessages.count > 1 {
+            let secondMessage = capturedMessages[1]
+            XCTAssertGreaterThan(secondMessage.1, 0.0, "Elapsed time should be positive for subsequent messages")
+            XCTAssertGreaterThan(secondMessage.2, 0.0, "Step duration should be positive for subsequent messages")
+        }
+        
+        // Verify last message indicates completion
+        let lastMessage = capturedMessages.last!
+        XCTAssertTrue(lastMessage.0.contains("Total SDK initialization completed"))
+        XCTAssertGreaterThan(lastMessage.1, 0.0, "Final message should have positive elapsed time")
+    }
+    
+    func testDebugCallbackNotCalledWhenNil() async throws {
+        // Mock the HTTP response
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let testConfig = """
+            {
+                "flags": {},
+                "createdAt": "2023-01-01T00:00:00.000Z", 
+                "environment": {"name": "test"},
+                "format": "SERVER_1_0"
+            }
+            """
+            return HTTPStubsResponse(data: testConfig.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Act - initialize without debug callback
+        let _ = try await EppoClient.initialize(
+            sdkKey: "test-sdk-key"
+            // No debugCallback parameter
+        )
+        
+        // Assert - we can't directly test that the callback wasn't called since it's nil,
+        // but we can verify the initialization completed successfully without errors
+        XCTAssertTrue(true, "Initialization should complete successfully without debug callback")
+    }
+    
+    func testDebugCallbackTimingIsMonotonicallyIncreasing() async throws {
+        // Arrange
+        var elapsedTimes: [Double] = []
+        let debugCallback: (String, Double, Double) -> Void = { _, elapsedMs, _ in
+            elapsedTimes.append(elapsedMs)
+        }
+        
+        // Mock the HTTP response
+        stub(condition: isHost("fscdn.eppo.cloud")) { _ in
+            let testConfig = """
+            {
+                "flags": {},
+                "createdAt": "2023-01-01T00:00:00.000Z",
+                "environment": {"name": "test"},
+                "format": "SERVER_1_0"
+            }
+            """
+            return HTTPStubsResponse(data: testConfig.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        // Act
+        let _ = try await EppoClient.initialize(
+            sdkKey: "test-sdk-key",
+            debugCallback: debugCallback
+        )
+        
+        // Assert
+        XCTAssertGreaterThan(elapsedTimes.count, 1, "Should have multiple timing measurements")
+        
+        // Verify elapsed times are monotonically increasing (or equal)
+        for i in 1..<elapsedTimes.count {
+            XCTAssertGreaterThanOrEqual(elapsedTimes[i], elapsedTimes[i-1], 
+                "Elapsed time should be monotonically increasing: \(elapsedTimes[i]) >= \(elapsedTimes[i-1])")
+        }
+        
+        // First elapsed time should be 0
+        XCTAssertEqual(elapsedTimes.first!, 0.0, "First elapsed time should be 0ms")
+    }
+}


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

```
// Simple print example with timing in milliseconds
let simplePrintCallback: (String, Double, Double) -> Void = { message, elapsedTimeMs, stepDurationMs in
    print("[\(String(format: "%.1f", elapsedTimeMs))ms] \(message) (step: \(String(format: "%.1f", stepDurationMs))ms)")
}

// DataDog example with custom attributes (pseudocode)
let dataDogCallback: (String, Double, Double) -> Void = { message, elapsedTimeMs, stepDurationMs in
    // Assuming DataDog SDK is available
    // RUMMonitor.shared().addAction(
    //     type: .custom,
    //     name: "eppo_initialization_step",
    //     attributes: [
    //         "message": message,
    //         "step_duration_ms": stepDurationMs,
    //         "elapsed_time_ms": elapsedTimeMs
    //     ]
    // )
}

// Usage examples:

// With simple print debugging
func initializeWithSimplePrint() async throws {
    let eppoClient = try await EppoClient.initialize(
        sdkKey: "your-sdk-key",
        debugCallback: simplePrintCallback
    )
}

// With DataDog integration
func initializeWithDataDog() async throws {
    let eppoClient = try await EppoClient.initialize(
        sdkKey: "your-sdk-key", 
        debugCallback: dataDogCallback
    )
}

// Without debugging (production)
func initializeProduction() async throws {
    let eppoClient = try await EppoClient.initialize(
        sdkKey: "your-sdk-key"
        // No debugCallback parameter = no debugging overhead
    )
}
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
