### PR TITLE
fix: decode base64-encoded values for all precomputed flag types

### DIFF
--- a/Sources/eppo/Constants.swift
+++ b/Sources/eppo/Constants.swift
@@ -1,6 +1,6 @@
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "5.3.3"
+public let sdkVersion = "5.3.4"
 
 public let defaultHost = "https://fscdn.eppo.cloud/api"
 public let precomputedBaseUrl = "https://fs-edge-assignment.eppo.cloud"

--- a/Sources/eppo/FlagEvaluation.swift
+++ b/Sources/eppo/FlagEvaluation.swift
@@ -48,21 +48,7 @@ public struct FlagEvaluation {
            let variationType = variationType,
            let decodedVariationKey = base64Decode(variation.key),
            let variationValue = try? variation.value.getStringValue(),
-           let decodedVariationValue = base64Decode(variationValue) {
-
-            var decodedValue: EppoValue = EppoValue.nullValue()
-
-            switch variationType {
-            case .boolean:
-                decodedValue = EppoValue(value: "true" == decodedVariationValue)
-            case .integer, .numeric:
-                if let doubleValue = Double(decodedVariationValue) {
-                    decodedValue = EppoValue(value: doubleValue)
-                }
-            case .string, .json:
-                decodedValue = EppoValue(value: decodedVariationValue)
-            }
-
+           let decodedValue = try? decodeVariationValue(encodedString: variationValue, variationType: variationType) {
             decodedVariation = UFC_Variation(key: decodedVariationKey, value: decodedValue)
         }
 

--- a/Sources/eppo/Obfuscation.swift
+++ b/Sources/eppo/Obfuscation.swift
@@ -50,7 +50,7 @@ func base64DecodeOrThrow(_ value: String) throws -> String {
 enum Base64DecodeError: Error, LocalizedError {
     case invalidBase64(String)
     case invalidUTF8(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .invalidBase64(let value):
@@ -60,6 +60,36 @@ enum Base64DecodeError: Error, LocalizedError {
         }
     }
 }
+
+/// Decodes a base64-encoded variation value and converts it to the appropriate EppoValue type.
+/// Used by precomputed flags (PrecomputedConfiguration).
+func decodeVariationValue(encodedString: String, variationType: VariationType) throws -> EppoValue {
+    let decodedString = try base64DecodeOrThrow(encodedString)
+    return convertDecodedStringToEppoValue(decodedString, isBoolean: variationType == .boolean, isNumeric: variationType == .integer || variationType == .numeric)
+}
+
+/// Decodes a base64-encoded variation value and converts it to the appropriate EppoValue type.
+/// Used by local evaluation (FlagEvaluation).
+func decodeVariationValue(encodedString: String, variationType: UFC_VariationType) throws -> EppoValue {
+    let decodedString = try base64DecodeOrThrow(encodedString)
+    return convertDecodedStringToEppoValue(decodedString, isBoolean: variationType == .boolean, isNumeric: variationType == .integer || variationType == .numeric)
+}
+
+/// Internal helper to convert a decoded string to the appropriate EppoValue type.
+private func convertDecodedStringToEppoValue(_ decodedString: String, isBoolean: Bool, isNumeric: Bool) -> EppoValue {
+    if isBoolean {
+        return EppoValue(value: "true" == decodedString.lowercased())
+    } else if isNumeric {
+        if let doubleValue = Double(decodedString) {
+            return EppoValue(value: doubleValue)
+        }
+        return EppoValue.nullValue()
+    } else {
+        // string or json
+        return EppoValue(value: decodedString)
+    }
+}
+
 
 let UTC_ISO_DATE_FORMAT: DateFormatter = {
     let formatter = DateFormatter()

--- a/Sources/eppo/dto/PrecomputedFlag.swift
+++ b/Sources/eppo/dto/PrecomputedFlag.swift
@@ -7,7 +7,7 @@ struct PrecomputedFlag: Codable, Equatable {
     let variationValue: EppoValue
     let extraLogging: [String: String]
     let doLog: Bool
-    
+
     init(
         allocationKey: String?,
         variationKey: String?,
@@ -22,6 +22,25 @@ struct PrecomputedFlag: Codable, Equatable {
         self.variationValue = variationValue
         self.extraLogging = extraLogging
         self.doLog = doLog
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        allocationKey = try container.decodeIfPresent(String.self, forKey: .allocationKey)
+        variationKey = try container.decodeIfPresent(String.self, forKey: .variationKey)
+        variationType = try container.decode(VariationType.self, forKey: .variationType)
+        variationValue = try container.decode(EppoValue.self, forKey: .variationValue)
+        extraLogging = try container.decodeIfPresent([String: String].self, forKey: .extraLogging) ?? [:]
+        doLog = try container.decode(Bool.self, forKey: .doLog)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case allocationKey
+        case variationKey
+        case variationType
+        case variationValue
+        case extraLogging
+        case doLog
     }
 }
 

--- a/Sources/eppo/precomputed/PrecomputedConfiguration.swift
+++ b/Sources/eppo/precomputed/PrecomputedConfiguration.swift
@@ -237,24 +237,7 @@ extension PrecomputedConfiguration {
         let decodedVariationValue: EppoValue
         do {
             let encodedString = try flag.variationValue.getStringValue()
-            let decodedString = try base64DecodeOrThrow(encodedString)
-
-            switch flag.variationType {
-            case .string, .json:
-                decodedVariationValue = EppoValue(value: decodedString)
-            case .boolean:
-                guard let boolValue = Bool(decodedString.lowercased()) else {
-                    print("Warning: Failed to parse boolean value '\(decodedString)', skipping flag")
-                    return nil
-                }
-                decodedVariationValue = EppoValue(value: boolValue)
-            case .integer, .numeric:
-                guard let doubleValue = Double(decodedString) else {
-                    print("Warning: Failed to parse numeric value '\(decodedString)', skipping flag")
-                    return nil
-                }
-                decodedVariationValue = EppoValue(value: doubleValue)
-            }
+            decodedVariationValue = try decodeVariationValue(encodedString: encodedString, variationType: flag.variationType)
         } catch {
             print("Warning: Failed to decode variationValue, skipping flag - error: \(error.localizedDescription)")
             return nil

--- a/Sources/eppo/precomputed/PrecomputedConfiguration.swift
+++ b/Sources/eppo/precomputed/PrecomputedConfiguration.swift
@@ -235,17 +235,29 @@ extension PrecomputedConfiguration {
         }
 
         let decodedVariationValue: EppoValue
-        if flag.variationType == .string || flag.variationType == .json {
-            do {
-                let encodedString = try flag.variationValue.getStringValue()
-                let decodedString = try base64DecodeOrThrow(encodedString)
+        do {
+            let encodedString = try flag.variationValue.getStringValue()
+            let decodedString = try base64DecodeOrThrow(encodedString)
+
+            switch flag.variationType {
+            case .string, .json:
                 decodedVariationValue = EppoValue(value: decodedString)
-            } catch {
-                print("Warning: Failed to decode variationValue, skipping flag - error: \(error.localizedDescription)")
-                return nil
+            case .boolean:
+                guard let boolValue = Bool(decodedString.lowercased()) else {
+                    print("Warning: Failed to parse boolean value '\(decodedString)', skipping flag")
+                    return nil
+                }
+                decodedVariationValue = EppoValue(value: boolValue)
+            case .integer, .numeric:
+                guard let doubleValue = Double(decodedString) else {
+                    print("Warning: Failed to parse numeric value '\(decodedString)', skipping flag")
+                    return nil
+                }
+                decodedVariationValue = EppoValue(value: doubleValue)
             }
-        } else {
-            decodedVariationValue = flag.variationValue
+        } catch {
+            print("Warning: Failed to decode variationValue, skipping flag - error: \(error.localizedDescription)")
+            return nil
         }
 
         var decodedExtraLogging: [String: String] = [:]

--- a/Tests/eppo/precomputed/PrecomputedConfigurationTests.swift
+++ b/Tests/eppo/precomputed/PrecomputedConfigurationTests.swift
@@ -94,6 +94,8 @@ class PrecomputedConfigurationTests: XCTestCase {
 
     func testPublicStringAPIWithComplexFlags() throws {
         // Test public String API with multiple flags and complex scenarios
+        // Note: All variation values in wire format are base64-encoded strings
+        // "dHJ1ZQ==" is base64 for "true"
         let wireFormatJSON = """
         {
             "version": 1,
@@ -104,7 +106,7 @@ class PrecomputedConfigurationTests: XCTestCase {
                     "numericAttributes": {}
                 },
                 "fetchedAt": "2024-11-18T14:23:25.123Z",
-                "response": "{\\"createdAt\\":\\"2024-11-18T14:23:25.123Z\\",\\"format\\":\\"PRECOMPUTED\\",\\"salt\\":\\"c29kaXVtY2hsb3JpZGU=\\",\\"obfuscated\\":true,\\"environment\\":{\\"name\\":\\"Test\\"},\\"flags\\":{\\"string-flag\\":{\\"allocationKey\\":\\"YWxsb2NhdGlvbi0xMjM=\\",\\"variationKey\\":\\"dmFyaWF0aW9uLTEyMw==\\",\\"variationType\\":\\"STRING\\",\\"variationValue\\":\\"cmVk\\",\\"extraLogging\\":{},\\"doLog\\":true},\\"boolean-flag\\":{\\"allocationKey\\":\\"YWxsb2NhdGlvbi0xMjQ=\\",\\"variationKey\\":\\"dmFyaWF0aW9uLTEyNA==\\",\\"variationType\\":\\"BOOLEAN\\",\\"variationValue\\":true,\\"extraLogging\\":{\\"aG9sZG91dEtleQ==\\":\\"ZmVhdHVyZS1yb2xsb3V0\\",\\"aG9sZG91dFZhcmlhdGlvbg==\\":\\"YWxsX3NoaXBwZWQ=\\"},\\"doLog\\":false}}}"
+                "response": "{\\"createdAt\\":\\"2024-11-18T14:23:25.123Z\\",\\"format\\":\\"PRECOMPUTED\\",\\"salt\\":\\"c29kaXVtY2hsb3JpZGU=\\",\\"obfuscated\\":true,\\"environment\\":{\\"name\\":\\"Test\\"},\\"flags\\":{\\"string-flag\\":{\\"allocationKey\\":\\"YWxsb2NhdGlvbi0xMjM=\\",\\"variationKey\\":\\"dmFyaWF0aW9uLTEyMw==\\",\\"variationType\\":\\"STRING\\",\\"variationValue\\":\\"cmVk\\",\\"extraLogging\\":{},\\"doLog\\":true},\\"boolean-flag\\":{\\"allocationKey\\":\\"YWxsb2NhdGlvbi0xMjQ=\\",\\"variationKey\\":\\"dmFyaWF0aW9uLTEyNA==\\",\\"variationType\\":\\"BOOLEAN\\",\\"variationValue\\":\\"dHJ1ZQ==\\",\\"extraLogging\\":{\\"aG9sZG91dEtleQ==\\":\\"ZmVhdHVyZS1yb2xsb3V0\\",\\"aG9sZG91dFZhcmlhdGlvbg==\\":\\"YWxsX3NoaXBwZWQ=\\"},\\"doLog\\":false}}}"
             }
         }
         """
@@ -126,7 +128,8 @@ class PrecomputedConfigurationTests: XCTestCase {
         let boolFlag = config.flags["boolean-flag"]
         XCTAssertNotNil(boolFlag)
         XCTAssertEqual(boolFlag?.variationType, .boolean)
-        XCTAssertEqual(try boolFlag?.variationValue.getBoolValue(), true)
+        // Raw value is base64-encoded string "dHJ1ZQ==" before decoding
+        XCTAssertEqual(try boolFlag?.variationValue.getStringValue(), "dHJ1ZQ==")
         XCTAssertFalse(boolFlag?.doLog ?? true)
     }
 

--- a/Tests/eppo/precomputed/PrecomputedConfigurationWireTests.swift
+++ b/Tests/eppo/precomputed/PrecomputedConfigurationWireTests.swift
@@ -31,6 +31,73 @@ class PrecomputedConfigurationWireTests: XCTestCase {
         XCTAssertEqual(client.getStringAssignment(flagKey: "unknown-flag", defaultValue: "fallback"), "fallback")
     }
 
+    func testBooleanFlagAssignmentWithBase64EncodedValue() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // The test data has "boolean-flag" with variationValue "dHJ1ZQ==" (base64 of "true")
+        let result = client.getBooleanAssignment(flagKey: "boolean-flag", defaultValue: false)
+        XCTAssertTrue(result, "Boolean flag should return true, not the default value false")
+    }
+
+    func testIntegerFlagAssignmentWithBase64EncodedValue() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // The test data has "integer-flag" with variationValue "NDI=" (base64 of "42")
+        let result = client.getIntegerAssignment(flagKey: "integer-flag", defaultValue: 0)
+        XCTAssertEqual(result, 42, "Integer flag should return 42, not the default value 0")
+    }
+
+    func testNumericFlagAssignmentWithBase64EncodedValue() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // The test data has "numeric-flag" with variationValue "My4xNA==" (base64 of "3.14")
+        let result = client.getNumericAssignment(flagKey: "numeric-flag", defaultValue: 0.0)
+        XCTAssertEqual(result, 3.14, accuracy: 0.001, "Numeric flag should return 3.14, not the default value 0.0")
+    }
+
+    func testAllFlagTypesWithBase64EncodedValues() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // Test all flag types in one test to verify comprehensive base64 decoding
+        XCTAssertEqual(client.getStringAssignment(flagKey: "string-flag", defaultValue: "default"), "red")
+        XCTAssertTrue(client.getBooleanAssignment(flagKey: "boolean-flag", defaultValue: false))
+        XCTAssertEqual(client.getIntegerAssignment(flagKey: "integer-flag", defaultValue: 0), 42)
+        XCTAssertEqual(client.getNumericAssignment(flagKey: "numeric-flag", defaultValue: 0.0), 3.14, accuracy: 0.001)
+        XCTAssertTrue(client.getJSONStringAssignment(flagKey: "json-flag", defaultValue: "{}").contains("key"))
+    }
+
     // MARK: - Helper Methods
 
     private func loadPrecomputedConfig() throws -> PrecomputedConfiguration {

--- a/Tests/eppo/precomputed/PrecomputedTestHelpers.swift
+++ b/Tests/eppo/precomputed/PrecomputedTestHelpers.swift
@@ -13,6 +13,7 @@ func createTestFlag(
     let encodedAllocationKey = allocationKey.map { base64Encode($0) }
     let encodedVariationKey = variationKey.map { base64Encode($0) }
 
+    // All variation values are base64-encoded strings in the wire format
     let encodedVariationValue: EppoValue
     switch variationType {
     case .string, .json:
@@ -23,25 +24,27 @@ func createTestFlag(
         }
     case .boolean:
         if let boolValue = variationValue as? Bool {
-            encodedVariationValue = EppoValue(value: boolValue)
+            encodedVariationValue = EppoValue(value: base64Encode(boolValue ? "true" : "false"))
         } else if let stringValue = variationValue as? String {
+            // Allow passing raw string for edge case testing (e.g., "not a boolean")
             encodedVariationValue = EppoValue(value: base64Encode(stringValue))
         } else {
             fatalError("BOOLEAN variation values must be Bool or String type")
         }
     case .integer:
         if let doubleValue = variationValue as? Double {
-            encodedVariationValue = EppoValue(value: doubleValue)
+            let intValue = Int(doubleValue)
+            encodedVariationValue = EppoValue(value: base64Encode(String(intValue)))
         } else if let intValue = variationValue as? Int {
-            encodedVariationValue = EppoValue(value: intValue)
+            encodedVariationValue = EppoValue(value: base64Encode(String(intValue)))
         } else {
             fatalError("INTEGER variation values must be Double or Int type")
         }
     case .numeric:
         if let doubleValue = variationValue as? Double {
-            encodedVariationValue = EppoValue(value: doubleValue)
+            encodedVariationValue = EppoValue(value: base64Encode(String(doubleValue)))
         } else if let intValue = variationValue as? Int {
-            encodedVariationValue = EppoValue(value: intValue)
+            encodedVariationValue = EppoValue(value: base64Encode(String(intValue)))
         } else {
             fatalError("NUMERIC variation values must be Double or Int type")
         }


### PR DESCRIPTION
:tickets: Fixes [FFL-1916](https://datadoghq.atlassian.net/browse/FFL-1916)
:scroll: Design Doc: N/A

## Motivation and Context

When using `EppoPrecomputedClient`, all flags of type BOOLEAN, INTEGER, and NUMERIC always return the `defaultValue` instead of the actual assigned value.

The precomputed API endpoint returns **all** variation values as base64-encoded strings, regardless of type. For example:
- BOOLEAN `true` arrives as `"dHJ1ZQ=="` (base64 of "true")
- INTEGER `42` arrives as `"NDI="` (base64 of "42")
- NUMERIC `3.14` arrives as `"My4xNA=="` (base64 of "3.14")

However, the `decodeFlag` method in `PrecomputedConfiguration.swift` only applied base64 decoding for `.string` and `.json` variation types. For other types, the raw base64-encoded string was used as-is, causing type conversion to fail silently and return the default value.

## Description

1. **Extended `decodeFlag` to handle all variation types:**
   - STRING/JSON: Base64-decode to string (unchanged)
   - BOOLEAN: Base64-decode, then parse with `Bool(decodedString.lowercased())`
   - INTEGER/NUMERIC: Base64-decode, then parse with `Double(decodedString)`

2. **Fixed test helper to properly encode all types:**
   - Updated `createTestFlag` in `PrecomputedTestHelpers.swift` to base64-encode boolean, integer, and numeric values (matching the actual wire format)

3. **Added custom decoder for `PrecomputedFlag`:**
   - Handle missing `extraLogging` field gracefully (defaults to empty dictionary)

## How has this been documented?

No documentation changes required - this is a bug fix that makes the SDK behave as expected.

## How has this been tested?

- Added 4 new tests in `PrecomputedConfigurationWireTests.swift`:
  - `testBooleanFlagAssignmentWithBase64EncodedValue`
  - `testIntegerFlagAssignmentWithBase64EncodedValue`
  - `testNumericFlagAssignmentWithBase64EncodedValue`
  - `testAllFlagTypesWithBase64EncodedValues`
- All 208 existing tests continue to pass
- Manually tested with a toy iOS app against real precomputed API responses
  - Used the `dart-test-flag-<type>` flags with defaults (`"DEFAULT"`, `false`, `-1`, `-1.0`, and `{}`) and observed that the precomputed client returned values configured for the flags instead
![demo](https://github.com/user-attachments/assets/1da37636-600d-4d18-bbd4-eebba7cc2766)
