### PR TITLE
feat: add bandits support to precomputed client

### DIFF
--- a/Sources/eppo/Constants.swift
+++ b/Sources/eppo/Constants.swift
@@ -1,6 +1,6 @@
 // todo: make this a build argument (FF-1944)
 public let sdkName = "ios"
-public let sdkVersion = "5.3.4"
+public let sdkVersion = "5.4.0"
 
 public let defaultHost = "https://fscdn.eppo.cloud/api"
 public let precomputedBaseUrl = "https://fs-edge-assignment.eppo.cloud"

--- a/Sources/eppo/dto/BanditEvent.swift
+++ b/Sources/eppo/dto/BanditEvent.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Event data for bandit action logging.
+/// This structure matches the IBanditEvent interface in the JS SDK.
+public struct BanditEvent {
+    /// ISO 8601 timestamp of when the event occurred
+    public let timestamp: String
+
+    /// The feature flag key associated with this bandit
+    public let flagKey: String
+
+    /// The bandit key
+    public let banditKey: String
+
+    /// The subject key (user identifier)
+    public let subjectKey: String
+
+    /// The selected action, or nil if no action was selected
+    public let action: String?
+
+    /// The probability of selecting this action
+    public let actionProbability: Double
+
+    /// The optimality gap for this action
+    public let optimalityGap: Double
+
+    /// The model version used for this assignment
+    public let modelVersion: String
+
+    /// Numeric attributes of the subject
+    public let subjectNumericAttributes: [String: Double]
+
+    /// Categorical attributes of the subject
+    public let subjectCategoricalAttributes: [String: String]
+
+    /// Numeric attributes of the selected action
+    public let actionNumericAttributes: [String: Double]
+
+    /// Categorical attributes of the selected action
+    public let actionCategoricalAttributes: [String: String]
+
+    /// Additional metadata about the assignment
+    public let metaData: [String: String]
+
+    public init(
+        timestamp: String,
+        flagKey: String,
+        banditKey: String,
+        subjectKey: String,
+        action: String?,
+        actionProbability: Double,
+        optimalityGap: Double,
+        modelVersion: String,
+        subjectNumericAttributes: [String: Double],
+        subjectCategoricalAttributes: [String: String],
+        actionNumericAttributes: [String: Double],
+        actionCategoricalAttributes: [String: String],
+        metaData: [String: String]
+    ) {
+        self.timestamp = timestamp
+        self.flagKey = flagKey
+        self.banditKey = banditKey
+        self.subjectKey = subjectKey
+        self.action = action
+        self.actionProbability = actionProbability
+        self.optimalityGap = optimalityGap
+        self.modelVersion = modelVersion
+        self.subjectNumericAttributes = subjectNumericAttributes
+        self.subjectCategoricalAttributes = subjectCategoricalAttributes
+        self.actionNumericAttributes = actionNumericAttributes
+        self.actionCategoricalAttributes = actionCategoricalAttributes
+        self.metaData = metaData
+    }
+}
+
+/// Type alias for the bandit logger callback
+public typealias BanditLogger = (BanditEvent) -> Void

--- a/Sources/eppo/dto/BanditResult.swift
+++ b/Sources/eppo/dto/BanditResult.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Result of a bandit action assignment.
+/// Contains the variation from the feature flag and the selected action (if any).
+public struct BanditResult {
+    /// The variation value from the feature flag assignment
+    public let variation: String
+
+    /// The selected bandit action, or nil if no bandit was assigned
+    public let action: String?
+
+    public init(variation: String, action: String?) {
+        self.variation = variation
+        self.action = action
+    }
+}

--- a/Sources/eppo/dto/PrecomputedBandit.swift
+++ b/Sources/eppo/dto/PrecomputedBandit.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Represents a precomputed bandit assignment from the server.
+/// String fields are Base64 encoded in the wire format.
+struct PrecomputedBandit: Codable, Equatable {
+    let banditKey: String
+    let action: String?
+    let modelVersion: String?
+    let actionNumericAttributes: [String: String]?
+    let actionCategoricalAttributes: [String: String]?
+    let actionProbability: Double
+    let optimalityGap: Double
+
+    init(
+        banditKey: String,
+        action: String?,
+        modelVersion: String?,
+        actionNumericAttributes: [String: String]? = nil,
+        actionCategoricalAttributes: [String: String]? = nil,
+        actionProbability: Double,
+        optimalityGap: Double
+    ) {
+        self.banditKey = banditKey
+        self.action = action
+        self.modelVersion = modelVersion
+        self.actionNumericAttributes = actionNumericAttributes
+        self.actionCategoricalAttributes = actionCategoricalAttributes
+        self.actionProbability = actionProbability
+        self.optimalityGap = optimalityGap
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        banditKey = try container.decode(String.self, forKey: .banditKey)
+        action = try container.decodeIfPresent(String.self, forKey: .action)
+        modelVersion = try container.decodeIfPresent(String.self, forKey: .modelVersion)
+        actionNumericAttributes = try container.decodeIfPresent([String: String].self, forKey: .actionNumericAttributes)
+        actionCategoricalAttributes = try container.decodeIfPresent([String: String].self, forKey: .actionCategoricalAttributes)
+        actionProbability = try container.decodeIfPresent(Double.self, forKey: .actionProbability) ?? 0.0
+        optimalityGap = try container.decodeIfPresent(Double.self, forKey: .optimalityGap) ?? 0.0
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case banditKey
+        case action
+        case modelVersion
+        case actionNumericAttributes
+        case actionCategoricalAttributes
+        case actionProbability
+        case optimalityGap
+    }
+}
+
+/// Decoded version of PrecomputedBandit with Base64-decoded string fields
+struct DecodedPrecomputedBandit: Codable, Equatable {
+    let banditKey: String
+    let action: String?
+    let modelVersion: String?
+    let actionNumericAttributes: [String: Double]
+    let actionCategoricalAttributes: [String: String]
+    let actionProbability: Double
+    let optimalityGap: Double
+}

--- a/Sources/eppo/precomputed/EppoPrecomputedClient.swift
+++ b/Sources/eppo/precomputed/EppoPrecomputedClient.swift
@@ -23,6 +23,8 @@ public class EppoPrecomputedClient {
     private let configurationStore: PrecomputedConfigurationStore
     private let assignmentLogger: AssignmentLogger?
     private let assignmentCache: AssignmentCache?
+    private let banditLogger: BanditLogger?
+    private let banditAssignmentCache: AssignmentCache?
 
     // MARK: - Network Components  
     private var requestor: PrecomputedRequestor?
@@ -44,6 +46,8 @@ public class EppoPrecomputedClient {
         sdkKey: String,
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
+        banditLogger: BanditLogger? = nil,
+        banditAssignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         initialPrecomputedConfiguration: PrecomputedConfiguration? = nil,
         withPersistentCache: Bool = true,
         configurationChangeCallback: ConfigurationChangeCallback? = nil
@@ -51,6 +55,8 @@ public class EppoPrecomputedClient {
         self.sdkKey = sdkKey
         self.assignmentLogger = assignmentLogger
         self.assignmentCache = assignmentCache
+        self.banditLogger = banditLogger
+        self.banditAssignmentCache = banditAssignmentCache
         self.configurationStore = PrecomputedConfigurationStore(withPersistentCache: withPersistentCache)
         self.configurationChangeCallback = configurationChangeCallback
 
@@ -67,6 +73,8 @@ public class EppoPrecomputedClient {
         initialPrecomputedConfiguration: PrecomputedConfiguration? = nil,
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
+        banditLogger: BanditLogger? = nil,
+        banditAssignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         withPersistentCache: Bool = true,
         configurationChangeCallback: ConfigurationChangeCallback? = nil
     ) -> EppoPrecomputedClient {
@@ -79,6 +87,8 @@ public class EppoPrecomputedClient {
                 sdkKey: sdkKey,
                 assignmentLogger: assignmentLogger,
                 assignmentCache: assignmentCache,
+                banditLogger: banditLogger,
+                banditAssignmentCache: banditAssignmentCache,
                 initialPrecomputedConfiguration: initialPrecomputedConfiguration,
                 withPersistentCache: withPersistentCache,
                 configurationChangeCallback: configurationChangeCallback
@@ -100,6 +110,8 @@ public class EppoPrecomputedClient {
         precompute: Precompute,
         assignmentLogger: AssignmentLogger? = nil,
         assignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
+        banditLogger: BanditLogger? = nil,
+        banditAssignmentCache: AssignmentCache? = InMemoryAssignmentCache(),
         host: String? = nil,
         withPersistentCache: Bool = true,
         configurationChangeCallback: ConfigurationChangeCallback? = nil,
@@ -113,6 +125,8 @@ public class EppoPrecomputedClient {
             initialPrecomputedConfiguration: nil,
             assignmentLogger: assignmentLogger,
             assignmentCache: assignmentCache,
+            banditLogger: banditLogger,
+            banditAssignmentCache: banditAssignmentCache,
             withPersistentCache: withPersistentCache,
             configurationChangeCallback: configurationChangeCallback
         )
@@ -236,6 +250,44 @@ public class EppoPrecomputedClient {
 
     public func getJSONStringAssignment(flagKey: String, defaultValue: String) -> String {
         return getPrecomputedAssignment(flagKey: flagKey, defaultValue: defaultValue, expectedType: .json)
+    }
+
+    // MARK: - Bandit Methods
+
+    /// Get bandit action for a flag
+    /// - Parameters:
+    ///   - flagKey: The feature flag key
+    ///   - defaultValue: Default variation to return if no assignment
+    /// - Returns: BanditResult containing the variation and optional action
+    public func getBanditAction(flagKey: String, defaultValue: String) -> BanditResult {
+        guard configurationStore.isInitialized() else {
+            return BanditResult(variation: defaultValue, action: nil)
+        }
+
+        guard let decodedConfig = configurationStore.getDecodedConfiguration() else {
+            return BanditResult(variation: defaultValue, action: nil)
+        }
+
+        let hashedFlagKey = getMD5Hex(flagKey, salt: decodedConfig.decodedSalt)
+
+        // First check if there's a bandit assignment for this flag
+        guard let bandit = configurationStore.getDecodedBandit(forKey: hashedFlagKey) else {
+            // No bandit, fall back to regular string assignment
+            let variation = getStringAssignment(flagKey: flagKey, defaultValue: defaultValue)
+            return BanditResult(variation: variation, action: nil)
+        }
+
+        // Get the variation from the bandit
+        let variation = bandit.banditKey
+        let action = bandit.action
+
+        // Log the bandit event
+        logBanditAction(
+            flagKey: flagKey,
+            bandit: bandit
+        )
+
+        return BanditResult(variation: variation, action: action)
     }
 
     // MARK: - Internal Assignment Logic
@@ -365,6 +417,82 @@ public class EppoPrecomputedClient {
             flagKey: assignment.featureFlag,
             allocationKey: allocationKey,
             variationKey: variationKey
+        )
+
+        return cache.shouldLogAssignment(key: cacheKey)
+    }
+
+    // MARK: - Bandit Logging
+
+    private func logBanditAction(
+        flagKey: String,
+        bandit: DecodedPrecomputedBandit
+    ) {
+        guard let precompute = currentPrecompute else {
+            return
+        }
+
+        guard let action = bandit.action else {
+            // No action to log
+            return
+        }
+
+        // Split subject attributes into numeric and categorical
+        var subjectNumericAttributes: [String: Double] = [:]
+        var subjectCategoricalAttributes: [String: String] = [:]
+
+        for (key, value) in precompute.subjectAttributes {
+            if value.isNumeric() {
+                if let doubleValue = try? value.getDoubleValue() {
+                    subjectNumericAttributes[key] = doubleValue
+                }
+            } else {
+                if let stringValue = try? value.getStringValue() {
+                    subjectCategoricalAttributes[key] = stringValue
+                }
+            }
+        }
+
+        let banditEvent = BanditEvent(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            flagKey: flagKey,
+            banditKey: bandit.banditKey,
+            subjectKey: precompute.subjectKey,
+            action: action,
+            actionProbability: bandit.actionProbability,
+            optimalityGap: bandit.optimalityGap,
+            modelVersion: bandit.modelVersion ?? "",
+            subjectNumericAttributes: subjectNumericAttributes,
+            subjectCategoricalAttributes: subjectCategoricalAttributes,
+            actionNumericAttributes: bandit.actionNumericAttributes,
+            actionCategoricalAttributes: bandit.actionCategoricalAttributes,
+            metaData: [
+                "obfuscated": "true",
+                "sdkLanguage": sdkName,
+                "sdkLibVersion": sdkVersion
+            ]
+        )
+
+        if shouldLogBanditAction(flagKey: flagKey, banditKey: bandit.banditKey, action: action) {
+            banditLogger?(banditEvent)
+        }
+    }
+
+    private func shouldLogBanditAction(flagKey: String, banditKey: String, action: String) -> Bool {
+        guard let cache = banditAssignmentCache else {
+            return true
+        }
+
+        guard let precompute = currentPrecompute else {
+            return true
+        }
+
+        // Use banditKey as allocationKey and action as variationKey for cache key
+        let cacheKey = AssignmentCacheKey(
+            subjectKey: precompute.subjectKey,
+            flagKey: flagKey,
+            allocationKey: banditKey,
+            variationKey: action
         )
 
         return cache.shouldLogAssignment(key: cacheKey)

--- a/Sources/eppo/precomputed/Precompute.swift
+++ b/Sources/eppo/precomputed/Precompute.swift
@@ -7,8 +7,17 @@ public struct Precompute: Codable {
     /// Additional attributes associated with the subject
     public let subjectAttributes: [String: EppoValue]
 
-    public init(subjectKey: String, subjectAttributes: [String: EppoValue] = [:]) {
+    /// Bandit actions available for each flag
+    /// Structure: flagKey -> actionKey -> attributes
+    public let banditActions: [String: [String: [String: EppoValue]]]?
+
+    public init(
+        subjectKey: String,
+        subjectAttributes: [String: EppoValue] = [:],
+        banditActions: [String: [String: [String: EppoValue]]]? = nil
+    ) {
         self.subjectKey = subjectKey
         self.subjectAttributes = subjectAttributes
+        self.banditActions = banditActions
     }
 }

--- a/Sources/eppo/precomputed/PrecomputedConfiguration.swift
+++ b/Sources/eppo/precomputed/PrecomputedConfiguration.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Represents the configuration for precomputed flag assignments
 public struct PrecomputedConfiguration: Codable {
     let flags: [String: PrecomputedFlag]
+    let bandits: [String: PrecomputedBandit]
     internal let salt: String
     internal let format: String
     internal let publishedAt: String
@@ -11,6 +12,7 @@ public struct PrecomputedConfiguration: Codable {
 
     init(
         flags: [String: PrecomputedFlag],
+        bandits: [String: PrecomputedBandit] = [:],
         salt: String,
         format: String,
         subject: Subject,
@@ -18,6 +20,7 @@ public struct PrecomputedConfiguration: Codable {
         environment: Environment? = nil
     ) {
         self.flags = flags
+        self.bandits = bandits
         self.salt = salt
         self.format = format
         self.publishedAt = publishedAt
@@ -45,6 +48,7 @@ public struct PrecomputedConfiguration: Codable {
         let responseDecoded = try decoder.decode(PrecomputedConfigurationFromJSON.self, from: responseData)
 
         self.flags = responseDecoded.flags
+        self.bandits = responseDecoded.bandits
         self.salt = responseDecoded.salt
         self.format = responseDecoded.format
         self.publishedAt = responseDecoded.publishedAt
@@ -61,6 +65,7 @@ public struct PrecomputedConfiguration: Codable {
 /// Helper struct for parsing JSON configuration without embedded subject
 private struct PrecomputedConfigurationFromJSON: Decodable {
     let flags: [String: PrecomputedFlag]
+    let bandits: [String: PrecomputedBandit]
     let salt: String
     let format: String
     let publishedAt: String
@@ -68,6 +73,7 @@ private struct PrecomputedConfigurationFromJSON: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case flags
+        case bandits
         case salt
         case format
         case createdAt
@@ -78,6 +84,7 @@ private struct PrecomputedConfigurationFromJSON: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         flags = try container.decode([String: PrecomputedFlag].self, forKey: .flags)
+        bandits = try container.decodeIfPresent([String: PrecomputedBandit].self, forKey: .bandits) ?? [:]
         salt = try container.decode(String.self, forKey: .salt)
         format = try container.decode(String.self, forKey: .format)
         publishedAt = try container.decode(String.self, forKey: .createdAt)
@@ -89,6 +96,7 @@ extension PrecomputedConfiguration {
 
     private enum CodingKeys: String, CodingKey {
         case flags
+        case bandits
         case salt
         case format
         case createdAt
@@ -100,6 +108,7 @@ extension PrecomputedConfiguration {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         flags = try container.decode([String: PrecomputedFlag].self, forKey: .flags)
+        bandits = try container.decodeIfPresent([String: PrecomputedBandit].self, forKey: .bandits) ?? [:]
         salt = try container.decode(String.self, forKey: .salt)
         format = try container.decode(String.self, forKey: .format)
         publishedAt = try container.decode(String.self, forKey: .createdAt)
@@ -111,6 +120,7 @@ extension PrecomputedConfiguration {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(flags, forKey: .flags)
+        try container.encode(bandits, forKey: .bandits)
         try container.encode(salt, forKey: .salt)
         try container.encode(format, forKey: .format)
         try container.encode(publishedAt, forKey: .createdAt)
@@ -180,6 +190,7 @@ struct DecodedPrecomputedFlag: Codable {
 
 struct DecodedPrecomputedConfiguration: Codable {
     let flags: [String: DecodedPrecomputedFlag]
+    let bandits: [String: DecodedPrecomputedBandit]
     let decodedSalt: String
     let format: String
     let publishedAt: String
@@ -199,8 +210,17 @@ extension PrecomputedConfiguration {
             decodedFlags[key] = decodedFlag
         }
 
+        var decodedBandits: [String: DecodedPrecomputedBandit] = [:]
+        for (key, bandit) in self.bandits {
+            guard let decodedBandit = decodeBandit(bandit) else {
+                continue
+            }
+            decodedBandits[key] = decodedBandit
+        }
+
         return DecodedPrecomputedConfiguration(
             flags: decodedFlags,
+            bandits: decodedBandits,
             decodedSalt: self.salt,
             format: self.format,
             publishedAt: self.publishedAt,
@@ -262,6 +282,73 @@ extension PrecomputedConfiguration {
             variationValue: decodedVariationValue,
             extraLogging: decodedExtraLogging,
             doLog: flag.doLog
+        )
+    }
+
+    private func decodeBandit(_ bandit: PrecomputedBandit) -> DecodedPrecomputedBandit? {
+        // Decode banditKey (required)
+        guard let decodedBanditKey = base64Decode(bandit.banditKey) else {
+            print("Warning: Failed to decode banditKey: \(bandit.banditKey)")
+            return nil
+        }
+
+        // Decode action (optional)
+        let decodedAction: String?
+        if let action = bandit.action {
+            decodedAction = base64Decode(action)
+            if decodedAction == nil {
+                print("Warning: Failed to decode action: \(action)")
+            }
+        } else {
+            decodedAction = nil
+        }
+
+        // Decode modelVersion (optional)
+        let decodedModelVersion: String?
+        if let modelVersion = bandit.modelVersion {
+            decodedModelVersion = base64Decode(modelVersion)
+            if decodedModelVersion == nil {
+                print("Warning: Failed to decode modelVersion: \(modelVersion)")
+            }
+        } else {
+            decodedModelVersion = nil
+        }
+
+        // Decode actionNumericAttributes (keys and values are Base64 encoded, values are numeric strings)
+        var decodedNumericAttributes: [String: Double] = [:]
+        if let numericAttrs = bandit.actionNumericAttributes {
+            for (encodedKey, encodedValue) in numericAttrs {
+                guard let decodedKey = base64Decode(encodedKey),
+                      let decodedValueStr = base64Decode(encodedValue),
+                      let doubleValue = Double(decodedValueStr) else {
+                    print("Warning: Failed to decode numeric attribute - key: \(encodedKey), value: \(encodedValue)")
+                    continue
+                }
+                decodedNumericAttributes[decodedKey] = doubleValue
+            }
+        }
+
+        // Decode actionCategoricalAttributes (keys and values are Base64 encoded)
+        var decodedCategoricalAttributes: [String: String] = [:]
+        if let categoricalAttrs = bandit.actionCategoricalAttributes {
+            for (encodedKey, encodedValue) in categoricalAttrs {
+                guard let decodedKey = base64Decode(encodedKey),
+                      let decodedValue = base64Decode(encodedValue) else {
+                    print("Warning: Failed to decode categorical attribute - key: \(encodedKey), value: \(encodedValue)")
+                    continue
+                }
+                decodedCategoricalAttributes[decodedKey] = decodedValue
+            }
+        }
+
+        return DecodedPrecomputedBandit(
+            banditKey: decodedBanditKey,
+            action: decodedAction,
+            modelVersion: decodedModelVersion,
+            actionNumericAttributes: decodedNumericAttributes,
+            actionCategoricalAttributes: decodedCategoricalAttributes,
+            actionProbability: bandit.actionProbability,
+            optimalityGap: bandit.optimalityGap
         )
     }
 }

--- a/Sources/eppo/precomputed/PrecomputedConfigurationStore.swift
+++ b/Sources/eppo/precomputed/PrecomputedConfigurationStore.swift
@@ -53,6 +53,14 @@ class PrecomputedConfigurationStore {
         return syncQueue.sync { self.decodedConfiguration?.flags[key] }
     }
 
+    func getDecodedBandit(forKey key: String) -> DecodedPrecomputedBandit? {
+        return syncQueue.sync { self.decodedConfiguration?.bandits[key] }
+    }
+
+    func getSalt() -> String? {
+        return syncQueue.sync { self.decodedConfiguration?.decodedSalt }
+    }
+
     /// Clear the persistent cache
     static func clearPersistentCache() {
         guard let cacheFileURL = Self.findCacheFileURL() else {

--- a/Sources/eppo/precomputed/PrecomputedRequestor.swift
+++ b/Sources/eppo/precomputed/PrecomputedRequestor.swift
@@ -38,7 +38,8 @@ class PrecomputedRequestor {
     func fetchPrecomputedFlags() async throws -> PrecomputedConfiguration {
         let payload = PrecomputedFlagsPayload(
             subjectKey: _precompute.subjectKey,
-            subjectAttributes: _precompute.subjectAttributes
+            subjectAttributes: _precompute.subjectAttributes,
+            banditActions: _precompute.banditActions
         )
 
         let url = try buildURL()
@@ -60,6 +61,7 @@ class PrecomputedRequestor {
             let serverResponse = try JSONDecoder().decode(PrecomputedServerResponse.self, from: data)
             return PrecomputedConfiguration(
                 flags: serverResponse.flags,
+                bandits: serverResponse.bandits,
                 salt: serverResponse.salt,
                 format: serverResponse.format,
                 subject: Subject(
@@ -122,15 +124,45 @@ extension PrecomputedRequestor {
 struct PrecomputedFlagsPayload: Encodable {
     let subjectKey: String
     let subjectAttributes: ContextAttributes
+    let banditActions: [String: [String: ContextAttributes]]?
 
     enum CodingKeys: String, CodingKey {
         case subjectKey = "subject_key"
         case subjectAttributes = "subject_attributes"
+        case banditActions = "bandit_actions"
     }
 
-    init(subjectKey: String, subjectAttributes: [String: EppoValue]) {
+    init(
+        subjectKey: String,
+        subjectAttributes: [String: EppoValue],
+        banditActions: [String: [String: [String: EppoValue]]]?
+    ) {
         self.subjectKey = subjectKey
         self.subjectAttributes = ContextAttributes(from: subjectAttributes)
+
+        // Transform banditActions to use ContextAttributes for each action
+        if let actions = banditActions {
+            var transformed: [String: [String: ContextAttributes]] = [:]
+            for (flagKey, actionMap) in actions {
+                var transformedActions: [String: ContextAttributes] = [:]
+                for (actionKey, attributes) in actionMap {
+                    transformedActions[actionKey] = ContextAttributes(from: attributes)
+                }
+                transformed[flagKey] = transformedActions
+            }
+            self.banditActions = transformed
+        } else {
+            self.banditActions = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(subjectKey, forKey: .subjectKey)
+        try container.encode(subjectAttributes, forKey: .subjectAttributes)
+        if let banditActions = banditActions, !banditActions.isEmpty {
+            try container.encode(banditActions, forKey: .banditActions)
+        }
     }
 }
 
@@ -162,10 +194,30 @@ struct ContextAttributes: Encodable {
 /// Server response format for precomputed flags
 struct PrecomputedServerResponse: Decodable {
     let flags: [String: PrecomputedFlag]
+    let bandits: [String: PrecomputedBandit]
     let salt: String
     let format: String
     let createdAt: String
     let environment: Environment?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        flags = try container.decode([String: PrecomputedFlag].self, forKey: .flags)
+        bandits = try container.decodeIfPresent([String: PrecomputedBandit].self, forKey: .bandits) ?? [:]
+        salt = try container.decode(String.self, forKey: .salt)
+        format = try container.decode(String.self, forKey: .format)
+        createdAt = try container.decode(String.self, forKey: .createdAt)
+        environment = try container.decodeIfPresent(Environment.self, forKey: .environment)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case flags
+        case bandits
+        case salt
+        case format
+        case createdAt
+        case environment
+    }
 }
 
 // MARK: - Errors

--- a/Tests/eppo/precomputed/EppoPrecomputedClientBanditTests.swift
+++ b/Tests/eppo/precomputed/EppoPrecomputedClientBanditTests.swift
@@ -1,0 +1,360 @@
+import XCTest
+@testable import EppoFlagging
+
+// Mock bandit logger to verify bandit logging behavior
+class MockBanditLogger {
+    private(set) var loggedEvents: [BanditEvent] = []
+    private let queue = DispatchQueue(label: "mock.bandit.logger.queue", attributes: .concurrent)
+
+    var logger: BanditLogger {
+        return { [weak self] event in
+            self?.queue.async(flags: .barrier) {
+                self?.loggedEvents.append(event)
+            }
+        }
+    }
+
+    func getLoggedEvents() -> [BanditEvent] {
+        queue.sync { loggedEvents }
+    }
+
+    func reset() {
+        queue.async(flags: .barrier) {
+            self.loggedEvents.removeAll()
+        }
+    }
+}
+
+class EppoPrecomputedClientBanditTests: XCTestCase {
+    var mockAssignmentLogger: MockAssignmentLogger!
+    var mockBanditLogger: MockBanditLogger!
+    var mockAssignmentCache: MockAssignmentCache!
+    var mockBanditCache: MockAssignmentCache!
+    var testSubjectKey: String!
+    var testSubjectAttributes: [String: EppoValue]!
+    var testConfiguration: PrecomputedConfiguration!
+
+    override func setUp() {
+        super.setUp()
+        EppoPrecomputedClient.resetForTesting()
+        mockAssignmentLogger = MockAssignmentLogger()
+        mockBanditLogger = MockBanditLogger()
+        mockAssignmentCache = MockAssignmentCache()
+        mockBanditCache = MockAssignmentCache()
+        testSubjectKey = "test-user-123"
+        testSubjectAttributes = [
+            "age": EppoValue(value: 25),
+            "country": EppoValue(value: "US")
+        ]
+
+        // Create test flags
+        let testFlags = createTestFlags([
+            ("bandit-flag", createTestFlag(
+                allocationKey: "allocation-1",
+                variationKey: "variant-a",
+                variationType: .string,
+                variationValue: "recommendation-model"
+            )),
+            ("string-flag", createTestFlag(
+                allocationKey: "allocation-2",
+                variationKey: "variant-b",
+                variationType: .string,
+                variationValue: "hello world"
+            ))
+        ])
+
+        // Create test bandits
+        let testBandits = createTestBandits([
+            ("bandit-flag", createTestBandit(
+                banditKey: "recommendation-model",
+                action: "show-promo",
+                modelVersion: "v1.2.3",
+                actionNumericAttributes: [
+                    "expectedConversion": 0.25,
+                    "expectedRevenue": 15.75
+                ],
+                actionCategoricalAttributes: [
+                    "category": "promotion",
+                    "placement": "home_screen"
+                ],
+                actionProbability: 0.85,
+                optimalityGap: 0.12
+            ))
+        ])
+
+        testConfiguration = PrecomputedConfiguration(
+            flags: testFlags,
+            bandits: testBandits,
+            salt: "test-salt",
+            format: "PRECOMPUTED",
+            subject: Subject(subjectKey: testSubjectKey, subjectAttributes: testSubjectAttributes),
+            publishedAt: ISO8601DateFormatter().string(from: Date()),
+            environment: Environment(name: "test")
+        )
+    }
+
+    override func tearDown() {
+        mockAssignmentLogger.reset()
+        mockBanditLogger.reset()
+        mockAssignmentCache.reset()
+        mockBanditCache.reset()
+        EppoPrecomputedClient.resetForTesting()
+        super.tearDown()
+    }
+
+    // MARK: - Test helpers
+
+    private func initializeClient() {
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "mock-api-key",
+            initialPrecomputedConfiguration: testConfiguration,
+            assignmentLogger: mockAssignmentLogger.logger,
+            assignmentCache: mockAssignmentCache,
+            banditLogger: mockBanditLogger.logger,
+            banditAssignmentCache: mockBanditCache
+        )
+    }
+
+    // MARK: - Bandit Action Tests
+
+    func testGetBanditActionWithBanditFlag() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        let result = client.getBanditAction(
+            flagKey: "bandit-flag",
+            defaultValue: "default"
+        )
+
+        XCTAssertEqual(result.variation, "recommendation-model")
+        XCTAssertEqual(result.action, "show-promo")
+    }
+
+    func testGetBanditActionWithNonBanditFlag() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        let result = client.getBanditAction(
+            flagKey: "string-flag",
+            defaultValue: "default"
+        )
+
+        // Should fall back to regular string assignment
+        XCTAssertEqual(result.variation, "hello world")
+        XCTAssertNil(result.action)
+    }
+
+    func testGetBanditActionWithMissingFlag() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        let result = client.getBanditAction(
+            flagKey: "non-existent-flag",
+            defaultValue: "default"
+        )
+
+        XCTAssertEqual(result.variation, "default")
+        XCTAssertNil(result.action)
+    }
+
+    func testGetBanditActionWithoutInitialization() {
+        XCTAssertThrowsError(try EppoPrecomputedClient.shared()) { error in
+            XCTAssertTrue(error is EppoPrecomputedClient.InitializationError)
+        }
+    }
+
+    // MARK: - Bandit Logging Tests
+
+    func testBanditLoggingForValidBandit() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        _ = client.getBanditAction(
+            flagKey: "bandit-flag",
+            defaultValue: "default"
+        )
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 1)
+
+        let event = loggedEvents[0]
+        XCTAssertEqual(event.flagKey, "bandit-flag")
+        XCTAssertEqual(event.banditKey, "recommendation-model")
+        XCTAssertEqual(event.subjectKey, "test-user-123")
+        XCTAssertEqual(event.action, "show-promo")
+        XCTAssertEqual(event.actionProbability, 0.85, accuracy: 0.001)
+        XCTAssertEqual(event.optimalityGap, 0.12, accuracy: 0.001)
+        XCTAssertEqual(event.modelVersion, "v1.2.3")
+
+        // Check action attributes
+        XCTAssertEqual(event.actionNumericAttributes["expectedConversion"] ?? 0, 0.25, accuracy: 0.001)
+        XCTAssertEqual(event.actionNumericAttributes["expectedRevenue"] ?? 0, 15.75, accuracy: 0.001)
+        XCTAssertEqual(event.actionCategoricalAttributes["category"], "promotion")
+        XCTAssertEqual(event.actionCategoricalAttributes["placement"], "home_screen")
+
+        // Check metadata
+        XCTAssertEqual(event.metaData["obfuscated"], "true")
+        XCTAssertNotNil(event.metaData["sdkLanguage"])
+        XCTAssertNotNil(event.metaData["sdkLibVersion"])
+    }
+
+    func testBanditLoggingIncludesSubjectAttributes() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        _ = client.getBanditAction(
+            flagKey: "bandit-flag",
+            defaultValue: "default"
+        )
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 1)
+
+        let event = loggedEvents[0]
+        XCTAssertEqual(event.subjectNumericAttributes["age"] ?? 0, 25, accuracy: 0.001)
+        XCTAssertEqual(event.subjectCategoricalAttributes["country"], "US")
+    }
+
+    func testNoLoggingForNonBanditFlag() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        _ = client.getBanditAction(
+            flagKey: "string-flag",
+            defaultValue: "default"
+        )
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 0, "Should not log bandit event for non-bandit flag")
+    }
+
+    func testBanditLoggingDeduplication() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        for _ in 0..<5 {
+            _ = client.getBanditAction(
+                flagKey: "bandit-flag",
+                defaultValue: "default"
+            )
+        }
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 1, "Should only log once due to caching")
+    }
+
+    func testBanditLoggingWithoutCache() throws {
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "mock-api-key",
+            initialPrecomputedConfiguration: testConfiguration,
+            assignmentLogger: mockAssignmentLogger.logger,
+            assignmentCache: nil,
+            banditLogger: mockBanditLogger.logger,
+            banditAssignmentCache: nil
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+        for _ in 0..<3 {
+            _ = client.getBanditAction(
+                flagKey: "bandit-flag",
+                defaultValue: "default"
+            )
+        }
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 3, "Should log every time without cache")
+    }
+
+    // MARK: - Concurrent Access Tests
+
+    func testConcurrentBanditAccess() throws {
+        initializeClient()
+
+        let client = try EppoPrecomputedClient.shared()
+        let expectation = XCTestExpectation(description: "Concurrent bandit access completes")
+        expectation.expectedFulfillmentCount = 50
+
+        DispatchQueue.concurrentPerform(iterations: 50) { _ in
+            let result = client.getBanditAction(
+                flagKey: "bandit-flag",
+                defaultValue: "default"
+            )
+            XCTAssertEqual(result.variation, "recommendation-model")
+            XCTAssertEqual(result.action, "show-promo")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 1, "Should only log once due to caching")
+    }
+
+    // MARK: - Bandit Without Action Tests
+
+    func testBanditWithoutAction() throws {
+        // Create bandit without action
+        let testBandits = createTestBandits([
+            ("bandit-no-action", createTestBandit(
+                banditKey: "model-without-action",
+                action: nil,
+                modelVersion: "v1.0.0",
+                actionProbability: 0.5,
+                optimalityGap: 0.1
+            ))
+        ])
+
+        let testFlags = createTestFlags([
+            ("bandit-no-action", createTestFlag(
+                allocationKey: "allocation-1",
+                variationKey: "variant-a",
+                variationType: .string,
+                variationValue: "model-without-action"
+            ))
+        ])
+
+        let config = PrecomputedConfiguration(
+            flags: testFlags,
+            bandits: testBandits,
+            salt: "test-salt",
+            format: "PRECOMPUTED",
+            subject: Subject(subjectKey: testSubjectKey, subjectAttributes: testSubjectAttributes),
+            publishedAt: ISO8601DateFormatter().string(from: Date()),
+            environment: Environment(name: "test")
+        )
+
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "mock-api-key",
+            initialPrecomputedConfiguration: config,
+            banditLogger: mockBanditLogger.logger,
+            banditAssignmentCache: mockBanditCache
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+        let result = client.getBanditAction(
+            flagKey: "bandit-no-action",
+            defaultValue: "default"
+        )
+
+        XCTAssertEqual(result.variation, "model-without-action")
+        XCTAssertNil(result.action)
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        // Should not log because there's no action
+        let loggedEvents = mockBanditLogger.getLoggedEvents()
+        XCTAssertEqual(loggedEvents.count, 0, "Should not log bandit event without action")
+    }
+}

--- a/Tests/eppo/precomputed/PrecomputedConfigurationWireTests.swift
+++ b/Tests/eppo/precomputed/PrecomputedConfigurationWireTests.swift
@@ -98,6 +98,62 @@ class PrecomputedConfigurationWireTests: XCTestCase {
         XCTAssertTrue(client.getJSONStringAssignment(flagKey: "json-flag", defaultValue: "{}").contains("key"))
     }
 
+    // MARK: - Bandit Tests with Shared Test Data
+
+    func testBanditActionWithSharedTestData() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // "string-flag" has a bandit associated with it in precomputed-v1.json
+        let result = client.getBanditAction(flagKey: "string-flag", defaultValue: "default")
+
+        XCTAssertEqual(result.variation, "recommendation-model-v1")
+        XCTAssertEqual(result.action, "show_red_button")
+    }
+
+    func testBanditActionWithExtraLoggingSharedTestData() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // "string-flag-with-extra-logging" has a bandit in precomputed-v1.json
+        let result = client.getBanditAction(flagKey: "string-flag-with-extra-logging", defaultValue: "default")
+
+        XCTAssertEqual(result.variation, "content-recommendation")
+        XCTAssertEqual(result.action, "featured_content")
+    }
+
+    func testBanditActionForNonBanditFlagSharedTestData() throws {
+        let config = try loadPrecomputedConfig()
+
+        EppoPrecomputedClient.resetForTesting()
+        _ = EppoPrecomputedClient.initializeOffline(
+            sdkKey: "test-key",
+            initialPrecomputedConfiguration: config
+        )
+
+        let client = try EppoPrecomputedClient.shared()
+
+        // "not-a-bandit-flag" has no bandit, should fall back to flag assignment
+        let result = client.getBanditAction(flagKey: "not-a-bandit-flag", defaultValue: "default")
+
+        XCTAssertEqual(result.variation, "control")
+        XCTAssertNil(result.action)
+    }
+
     // MARK: - Helper Methods
 
     private func loadPrecomputedConfig() throws -> PrecomputedConfiguration {

--- a/Tests/eppo/precomputed/PrecomputedRequestorTests.swift
+++ b/Tests/eppo/precomputed/PrecomputedRequestorTests.swift
@@ -143,7 +143,8 @@ class PrecomputedRequestorTests: XCTestCase {
             subjectAttributes: [
                 "age": EppoValue(value: 30),
                 "country": EppoValue(value: "UK")
-            ]
+            ],
+            banditActions: nil
         )
 
         let encoder = JSONEncoder()

--- a/Tests/eppo/precomputed/PrecomputedTestHelpers.swift
+++ b/Tests/eppo/precomputed/PrecomputedTestHelpers.swift
@@ -73,3 +73,49 @@ func createTestFlags(_ flags: [(key: String, flag: PrecomputedFlag)], salt: Stri
     }
     return result
 }
+
+/// Creates a PrecomputedBandit with base64-encoded values from unencoded inputs
+func createTestBandit(
+    banditKey: String,
+    action: String? = nil,
+    modelVersion: String? = nil,
+    actionNumericAttributes: [String: Double] = [:],
+    actionCategoricalAttributes: [String: String] = [:],
+    actionProbability: Double,
+    optimalityGap: Double
+) -> PrecomputedBandit {
+    let encodedBanditKey = base64Encode(banditKey)
+    let encodedAction = action.map { base64Encode($0) }
+    let encodedModelVersion = modelVersion.map { base64Encode($0) }
+
+    // Encode numeric attributes: both keys and values are base64 encoded
+    var encodedNumericAttributes: [String: String] = [:]
+    for (key, value) in actionNumericAttributes {
+        encodedNumericAttributes[base64Encode(key)] = base64Encode(String(value))
+    }
+
+    // Encode categorical attributes: both keys and values are base64 encoded
+    var encodedCategoricalAttributes: [String: String] = [:]
+    for (key, value) in actionCategoricalAttributes {
+        encodedCategoricalAttributes[base64Encode(key)] = base64Encode(value)
+    }
+
+    return PrecomputedBandit(
+        banditKey: encodedBanditKey,
+        action: encodedAction,
+        modelVersion: encodedModelVersion,
+        actionNumericAttributes: encodedNumericAttributes.isEmpty ? nil : encodedNumericAttributes,
+        actionCategoricalAttributes: encodedCategoricalAttributes.isEmpty ? nil : encodedCategoricalAttributes,
+        actionProbability: actionProbability,
+        optimalityGap: optimalityGap
+    )
+}
+
+func createTestBandits(_ bandits: [(key: String, bandit: PrecomputedBandit)], salt: String = "test-salt") -> [String: PrecomputedBandit] {
+    var result: [String: PrecomputedBandit] = [:]
+    for (key, bandit) in bandits {
+        let hashedKey = getMD5Hex(key, salt: salt)
+        result[hashedKey] = bandit
+    }
+    return result
+}


### PR DESCRIPTION
:tickets: Fixes N/A - New feature
:scroll: Design Doc: N/A

## Motivation and Context

Add contextual multi-armed bandit support to the iOS SDK's `EppoPrecomputedClient`, achieving feature parity with the Android and JS SDKs.

## Description

This PR adds the `getBanditAction()` method and all supporting infrastructure for bandits in precomputed flags:

**New Files:**
- `Sources/eppo/dto/PrecomputedBandit.swift` - Wire format and decoded bandit DTOs
- `Sources/eppo/dto/BanditResult.swift` - Public return type with variation and optional action
- `Sources/eppo/dto/BanditEvent.swift` - Logging model and `BanditLogger` type alias

**Modified Files:**
- `Precompute.swift` - Added `banditActions` parameter for specifying available actions per flag
- `PrecomputedConfiguration.swift` - Added bandits parsing and Base64 decoding
- `PrecomputedRequestor.swift` - Added `bandit_actions` to request payload and `bandits` to response handling
- `PrecomputedConfigurationStore.swift` - Added `getDecodedBandit()` method
- `EppoPrecomputedClient.swift` - Added `getBanditAction()`, `banditLogger`, and deduplication via `banditAssignmentCache`

**Key Features:**
- `getBanditAction(flagKey:defaultValue:)` returns `BanditResult` with variation and optional action
- Bandits keyed by MD5-hashed flag key (matching existing flag lookup pattern)
- Base64 decoding for obfuscated bandit data (banditKey, action, modelVersion, attributes)
- `BanditEvent` logging with deduplication
- Falls back to regular string assignment when no bandit exists for a flag
- Thread-safe concurrent access

## How has this been documented?

No external documentation changes required. The public API is straightforward:
- `getBanditAction(flagKey:defaultValue:)` - similar to existing assignment methods
- `banditLogger` parameter in initialization - similar to existing `assignmentLogger`

## How has this been tested?

- **Unit tests**: `EppoPrecomputedClientBanditTests.swift` - 11 tests covering:
  - Basic bandit action retrieval
  - Non-bandit flag fallback
  - Missing flag handling
  - Bandit logging with all event fields
  - Subject attribute splitting (numeric/categorical)
  - Logging deduplication
  - Concurrent access safety
  - Bandits without actions

- **Wire format tests**: `PrecomputedConfigurationWireTests.swift` - 3 new tests using shared `precomputed-v1.json` test data:
  - `testBanditActionWithSharedTestData`
  - `testBanditActionWithExtraLoggingSharedTestData`
  - `testBanditActionForNonBanditFlagSharedTestData`

- **End-to-end**: Verified with EppoButtonClicker test app against live Eppo backend

```
        let precompute = Precompute(
            subjectKey: "test-user-123",
            subjectAttributes: [
                "country": .valueOf("US"),
                "age": .valueOf(25),
                "isPremium": .valueOf(true)
            ],
            banditActions: [
                "sameeran-test-1": [
                    "action-a": [
                        "price": .valueOf(9.99),
                        "category": .valueOf("electronics")
                    ],
                    "action-b": [
                        "price": .valueOf(19.99),
                        "category": .valueOf("clothing")
                    ],
                    "action-c": [
                        "price": .valueOf(29.99),
                        "category": .valueOf("home")
                    ]
                ]
            ]
        )
```

https://github.com/user-attachments/assets/35f8b5a7-ca17-477c-84ee-0281809a1e9b

All tests passing: `swift test` ✅